### PR TITLE
V2.x/scjs 706 beautify examples

### DIFF
--- a/Examples/src/components/Examples/Charts2D/BasicChartTypes/LineChart/index.tsx
+++ b/Examples/src/components/Examples/Charts2D/BasicChartTypes/LineChart/index.tsx
@@ -82,8 +82,7 @@ export default function LineChart() {
 
     return (
         <div className={classes.ChartWrapper}>
-            {loading && <img src={image} className={classes.PreloadImage} alt="" />}
-            <div id={divElementId} style={{ opacity: !loading ? "1" : "0.5" }}></div>
+            <div id={divElementId}></div>
         </div>
     );
 }

--- a/Examples/src/components/Examples/Examples.module.scss
+++ b/Examples/src/components/Examples/Examples.module.scss
@@ -334,13 +334,6 @@
     }
 }
 
-.PreloadImage {
-    position: absolute;
-    top: 0;
-    width: 100%;
-    min-height: 100%;
-}
-
 .Lidar {
     min-height: 500;
     @include md {

--- a/Examples/src/components/Examples/ExamplesRoot.tsx
+++ b/Examples/src/components/Examples/ExamplesRoot.tsx
@@ -104,9 +104,7 @@ const ExamplesRoot: React.FC<TProps> = props => {
 
                         <div className={classes.ExampleWrapper}>
                             <div className={classes.Example}>
-                                <CSSTransition timeout={1500} in={render} mountOnEnter classNames="example-anim">
-                                    <ExampleComponent />
-                                </CSSTransition>{" "}
+                                <ExampleComponent />
                                 <div className={classes.ButtonsWrapper}>
                                     <Button
                                         onClick={() => {


### PR DESCRIPTION
Ongoing work to beautify examples. Some suggestions

1. Remove fade animation on the entire chart when switching
2. Switch all themes to JSLight. Pass theme into options so loader has light theme
3. Beautify the colours of plots / series / examples
4. Generally make it perrrty 