### PR TITLE
feat(examples): iframe charts without layout

### DIFF
--- a/Examples/src/components/App.tsx
+++ b/Examples/src/components/App.tsx
@@ -25,6 +25,9 @@ import { sciChartExamples } from "../helpers/SciChartExamples";
 
 export default function App() {
     const location = useLocation();
+    // For charts without layout we use '/iframe' prefix, for example '/iframe/javascript-multiline-labels'
+    const isIFrame = location.pathname.substring(1, 7) === 'iframe';
+    const pathname = isIFrame ? location.pathname.substring(7) : location.pathname;
 
     const isMedium = useMediaQuery((theme: Theme) => theme.breakpoints.down("md"));
 
@@ -52,7 +55,7 @@ export default function App() {
 
     const [isDrawerOpened, setIsDrawerOpened] = React.useState(false);
 
-    const currentExampleKey = Object.keys(EXAMPLES_PAGES).find(key => EXAMPLES_PAGES[key].path === location.pathname);
+    const currentExampleKey = Object.keys(EXAMPLES_PAGES).find(key => EXAMPLES_PAGES[key].path === pathname);
     const currentExample = EXAMPLES_PAGES[currentExampleKey];
     const currentExampleId = currentExample?.id;
 
@@ -85,6 +88,10 @@ export default function App() {
             setOpenedMenuItems(updatedOpenedItems);
         }
     }, [currentExampleId]);
+
+    if (isIFrame) {
+        return <AppRouter currentExample={currentExample} isIFrame={true}/>
+    }
 
     const testIsOpened = (id: string): boolean => !!openedMenuItems[id];
     return (

--- a/Examples/src/components/AppRouter/AppRouter.tsx
+++ b/Examples/src/components/AppRouter/AppRouter.tsx
@@ -4,28 +4,42 @@ import PageHome from "../PageHome/PageHome";
 import { PAGES } from "./pages";
 import { EXAMPLES_PAGES, TExamplePage } from "./examplePages";
 import ExamplesRoot from "../Examples/ExamplesRoot";
+import { getExampleComponent } from "./examples";
 
 type TProps = {
     currentExample: TExamplePage;
+    isIFrame?: boolean;
 };
 
 const examplePagesKeys = Object.keys(EXAMPLES_PAGES);
 
 export default function AppRouter(props: TProps) {
-    const { currentExample } = props;
-    return (
-        <Switch>
-            {examplePagesKeys.map(key => {
-                const exPage = EXAMPLES_PAGES[key];
-                return (
-                    <Route
-                        key={key}
-                        path={exPage.path}
-                        render={() => <ExamplesRoot examplePage={currentExample} />}
-                    />
-                );
-            })}
-            <Route path={PAGES.homapage.path} component={PageHome} />
-        </Switch>
-    );
+    const { currentExample, isIFrame = false } = props;
+    if (isIFrame) {
+        const ExampleComponent = getExampleComponent(currentExample.id);
+        return (
+            <Switch>
+                {examplePagesKeys.map(key => {
+                    const exPage = EXAMPLES_PAGES[key];
+                    return <Route key={key} path={`/iframe${exPage.path}`} component={ExampleComponent} />;
+                })}
+            </Switch>
+        );
+    } else {
+        return (
+            <Switch>
+                {examplePagesKeys.map(key => {
+                    const exPage = EXAMPLES_PAGES[key];
+                    return (
+                        <Route
+                            key={key}
+                            path={exPage.path}
+                            render={() => <ExamplesRoot examplePage={currentExample} />}
+                        />
+                    );
+                })}
+                <Route path={PAGES.homapage.path} component={PageHome} />
+            </Switch>
+        );
+    }
 }


### PR DESCRIPTION
For charts without layout we use '/iframe' prefix, for example '/iframe/javascript-multiline-labels'

![image](https://user-images.githubusercontent.com/1125328/189881885-e582b0c8-e16d-40a9-b93a-73d634689a0a.png)
