### PR TITLE
feat: change search box border color and add lightbox images

### DIFF
--- a/Examples/src/components/Gallery/GalleryCard.tsx
+++ b/Examples/src/components/Gallery/GalleryCard.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { useHistory, Link } from "react-router-dom";
 import classes from "./Gallery.module.scss";
-import {LazyLoadImage} from "react-lazy-load-image-component";
+import { Tooltip } from "@material-ui/core";
 
 type TProps = {
     imgPath: string;
@@ -17,8 +17,10 @@ const GalleryCard: React.FC<TProps> = props => {
 
     return (
         <div className={classes.GalleryItemCard}>
-            <Link className={classes.GalleryItemCardImage} to={examplePath} title={seoTitle}>
-                <LazyLoadImage src={imgPath} title={seoTitle} alt={title}/>
+            <Link className={classes.GalleryItemCardImage} to={examplePath}>
+                <Tooltip title={<img src={imgPath} width={600} height={600} alt="" />} placement="bottom">
+                    <img src={imgPath} data-title={seoTitle} alt="" />
+                </Tooltip>
                 <h5 className={classes.GalleryItemTitle}>{title}</h5>
             </Link>
         </div>

--- a/Examples/src/theme.ts
+++ b/Examples/src/theme.ts
@@ -1,4 +1,4 @@
-import green from "@material-ui/core/colors/green";
+import themeColor from "@material-ui/core/colors/cyan";
 import { createTheme } from "@material-ui/core/styles";
 
 export const customTheme = createTheme({
@@ -27,6 +27,6 @@ export const customTheme = createTheme({
         ].join(",")
     },
     palette: {
-        primary: green
+        primary: themeColor
     }
 });


### PR DESCRIPTION
HI @andyb1979 I did some changes:
* changed theme palette which affects on the search box border
* added Tooltip component to show lightbox images

![scichartdemo1](https://user-images.githubusercontent.com/1125328/203976125-9e47da67-c1f8-4011-b19f-ffe631888da2.png)
![scichartdemo2](https://user-images.githubusercontent.com/1125328/203976232-71068720-9d38-472a-a02f-34a4338f1ea9.png)
