### PR TITLE
refactor(examples) MUI style system migration

### DIFF
--- a/Examples/package-lock.json
+++ b/Examples/package-lock.json
@@ -41,6 +41,7 @@
                 "scichart-react": "^0.1.9",
                 "socket.io": "^4.5.2",
                 "socket.io-client": "^4.7.5",
+                "tss-react": "^4.9.13",
                 "websocket-ts": "^1.1.1"
             },
             "devDependencies": {
@@ -10870,6 +10871,30 @@
             },
             "engines": {
                 "node": ">=4"
+            }
+        },
+        "node_modules/tss-react": {
+            "version": "4.9.13",
+            "resolved": "https://registry.npmjs.org/tss-react/-/tss-react-4.9.13.tgz",
+            "integrity": "sha512-Gu19qqPH8/SAyKVIgDE5qHygirEDnNIQcXhiEc+l4Q9T7C1sfvUnbVWs+yBpmN26/wyk4FTOupjYS2wq4vH0yA==",
+            "dependencies": {
+                "@emotion/cache": "*",
+                "@emotion/serialize": "*",
+                "@emotion/utils": "*"
+            },
+            "peerDependencies": {
+                "@emotion/react": "^11.4.1",
+                "@emotion/server": "^11.4.0",
+                "@mui/material": "^5.0.0 || ^6.0.0",
+                "react": "^16.8.0 || ^17.0.2 || ^18.0.0"
+            },
+            "peerDependenciesMeta": {
+                "@emotion/server": {
+                    "optional": true
+                },
+                "@mui/material": {
+                    "optional": true
+                }
             }
         },
         "node_modules/tsutils": {

--- a/Examples/package-lock.json
+++ b/Examples/package-lock.json
@@ -19,7 +19,7 @@
                 "@mui/icons-material": "^5.15.20",
                 "@mui/lab": "^5.0.0-alpha.170",
                 "@mui/material": "^5.15.20",
-                "@mui/styles": "^5.15.21",
+                "@mui/styles": "^6.1.6",
                 "@types/react": "^18.3.11",
                 "chalk": "^4.1.0",
                 "codesandbox": "^2.2.3",
@@ -317,9 +317,9 @@
             }
         },
         "node_modules/@babel/runtime": {
-            "version": "7.24.7",
-            "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.24.7.tgz",
-            "integrity": "sha512-UwgBRMjJP+xv857DCngvqXI3Iq6J4v0wXmwc6sapg+zyhbwmQX67LUEFrkK5tbyJ30jGuG3ZvWpBiB9LCy1kWw==",
+            "version": "7.26.0",
+            "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.26.0.tgz",
+            "integrity": "sha512-FDSOghenHTiToteC/QRlv2q3DhPZ/oOXTBoirfWNx1Cx3TMVcGWQtMMmQcSvb/JjpNeGzx8Pq/b4fKEJuWm1sw==",
             "dependencies": {
                 "regenerator-runtime": "^0.14.0"
             },
@@ -425,11 +425,6 @@
                 "stylis": "4.2.0"
             }
         },
-        "node_modules/@emotion/babel-plugin/node_modules/@emotion/hash": {
-            "version": "0.9.2",
-            "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.9.2.tgz",
-            "integrity": "sha512-MyqliTZGuOm3+5ZRSaaBGP3USLw6+EGykkwZns2EPC5g8jJ4z9OrdZY9apkl3+UP9+sdz76YYkwCKP5gh8iY3g=="
-        },
         "node_modules/@emotion/babel-plugin/node_modules/escape-string-regexp": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
@@ -460,6 +455,11 @@
                 "@emotion/weak-memoize": "^0.4.0",
                 "stylis": "4.2.0"
             }
+        },
+        "node_modules/@emotion/hash": {
+            "version": "0.9.2",
+            "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.9.2.tgz",
+            "integrity": "sha512-MyqliTZGuOm3+5ZRSaaBGP3USLw6+EGykkwZns2EPC5g8jJ4z9OrdZY9apkl3+UP9+sdz76YYkwCKP5gh8iY3g=="
         },
         "node_modules/@emotion/is-prop-valid": {
             "version": "1.3.1",
@@ -508,11 +508,6 @@
                 "@emotion/utils": "^1.4.1",
                 "csstype": "^3.0.2"
             }
-        },
-        "node_modules/@emotion/serialize/node_modules/@emotion/hash": {
-            "version": "0.9.2",
-            "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.9.2.tgz",
-            "integrity": "sha512-MyqliTZGuOm3+5ZRSaaBGP3USLw6+EGykkwZns2EPC5g8jJ4z9OrdZY9apkl3+UP9+sdz76YYkwCKP5gh8iY3g=="
         },
         "node_modules/@emotion/serialize/node_modules/csstype": {
             "version": "3.1.3",
@@ -942,16 +937,16 @@
             "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
         },
         "node_modules/@mui/styles": {
-            "version": "5.15.21",
-            "resolved": "https://registry.npmjs.org/@mui/styles/-/styles-5.15.21.tgz",
-            "integrity": "sha512-XYGRd25kE31GCapoftHrWrhr3zCNZypraBO+UAWNaguSRZ24HAHEOxEkAOTXt71BzFgW7S0qoE4jmyx8DfgZIg==",
+            "version": "6.1.6",
+            "resolved": "https://registry.npmjs.org/@mui/styles/-/styles-6.1.6.tgz",
+            "integrity": "sha512-2cGEUMi4kYNskrg2Upe0bR3Th2/e4j3Vd6R2lIMksBDivJH9o+nkwLjtf91KUOhKZ4BReCDVDC398dbOs+Ygdw==",
             "dependencies": {
-                "@babel/runtime": "^7.23.9",
-                "@emotion/hash": "^0.9.1",
-                "@mui/private-theming": "^5.15.20",
-                "@mui/types": "^7.2.14",
-                "@mui/utils": "^5.15.20",
-                "clsx": "^2.1.0",
+                "@babel/runtime": "^7.26.0",
+                "@emotion/hash": "^0.9.2",
+                "@mui/private-theming": "^6.1.6",
+                "@mui/types": "^7.2.19",
+                "@mui/utils": "^6.1.6",
+                "clsx": "^2.1.1",
                 "csstype": "^3.1.3",
                 "hoist-non-react-statics": "^3.3.2",
                 "jss": "^10.10.0",
@@ -965,15 +960,15 @@
                 "prop-types": "^15.8.1"
             },
             "engines": {
-                "node": ">=12.0.0"
+                "node": ">=14.0.0"
             },
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/mui-org"
             },
             "peerDependencies": {
-                "@types/react": "^17.0.0 || ^18.0.0",
-                "react": "^17.0.0"
+                "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+                "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
             },
             "peerDependenciesMeta": {
                 "@types/react": {
@@ -981,10 +976,60 @@
                 }
             }
         },
-        "node_modules/@mui/styles/node_modules/@emotion/hash": {
-            "version": "0.9.1",
-            "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.9.1.tgz",
-            "integrity": "sha512-gJB6HLm5rYwSLI6PQa+X1t5CFGrv1J1TWG+sOyMCeKz2ojaj6Fnl/rZEspogG+cvqbt4AE/2eIyD2QfLKTBNlQ=="
+        "node_modules/@mui/styles/node_modules/@mui/private-theming": {
+            "version": "6.1.6",
+            "resolved": "https://registry.npmjs.org/@mui/private-theming/-/private-theming-6.1.6.tgz",
+            "integrity": "sha512-ioAiFckaD/fJSnTrUMWgjl9HYBWt7ixCh7zZw7gDZ+Tae7NuprNV6QJK95EidDT7K0GetR2rU3kAeIR61Myttw==",
+            "dependencies": {
+                "@babel/runtime": "^7.26.0",
+                "@mui/utils": "^6.1.6",
+                "prop-types": "^15.8.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/mui-org"
+            },
+            "peerDependencies": {
+                "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+                "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@mui/styles/node_modules/@mui/utils": {
+            "version": "6.1.6",
+            "resolved": "https://registry.npmjs.org/@mui/utils/-/utils-6.1.6.tgz",
+            "integrity": "sha512-sBS6D9mJECtELASLM+18WUcXF6RH3zNxBRFeyCRg8wad6NbyNrdxLuwK+Ikvc38sTZwBzAz691HmSofLqHd9sQ==",
+            "dependencies": {
+                "@babel/runtime": "^7.26.0",
+                "@mui/types": "^7.2.19",
+                "@types/prop-types": "^15.7.13",
+                "clsx": "^2.1.1",
+                "prop-types": "^15.8.1",
+                "react-is": "^18.3.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/mui-org"
+            },
+            "peerDependencies": {
+                "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+                "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                }
+            }
         },
         "node_modules/@mui/styles/node_modules/clsx": {
             "version": "2.1.1",
@@ -1052,11 +1097,11 @@
             "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
         },
         "node_modules/@mui/types": {
-            "version": "7.2.14",
-            "resolved": "https://registry.npmjs.org/@mui/types/-/types-7.2.14.tgz",
-            "integrity": "sha512-MZsBZ4q4HfzBsywtXgM1Ksj6HDThtiwmOKUXH1pKYISI9gAVXCNHNpo7TlGoGrBaYWZTdNoirIN7JsQcQUjmQQ==",
+            "version": "7.2.19",
+            "resolved": "https://registry.npmjs.org/@mui/types/-/types-7.2.19.tgz",
+            "integrity": "sha512-6XpZEM/Q3epK9RN8ENoXuygnqUQxE+siN/6rGRi2iwJPgBUR25mphYQ9ZI87plGh58YoZ5pp40bFvKYOCDJ3tA==",
             "peerDependencies": {
-                "@types/react": "^17.0.0 || ^18.0.0"
+                "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0"
             },
             "peerDependenciesMeta": {
                 "@types/react": {
@@ -1394,9 +1439,9 @@
             "dev": true
         },
         "node_modules/@types/prop-types": {
-            "version": "15.7.12",
-            "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.12.tgz",
-            "integrity": "sha512-5zvhXYtRNRluoE/jAp4GVsSduVUzNWKkOZrCDBWYtE7biZywwdC2AcEzg+cSMLFRfVgeAFqpfNabiPjxFddV1Q=="
+            "version": "15.7.13",
+            "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.13.tgz",
+            "integrity": "sha512-hCZTSvwbzWGvhqxp/RqVqwU999pBf2vp7hzIjiYOsl8wqOmUxkQ6ddw1cV3l8811+kdUFus/q4d1Y3E3SyEifA=="
         },
         "node_modules/@types/qs": {
             "version": "6.9.15",

--- a/Examples/package-lock.json
+++ b/Examples/package-lock.json
@@ -19,7 +19,6 @@
                 "@mui/icons-material": "^5.15.20",
                 "@mui/lab": "^5.0.0-alpha.170",
                 "@mui/material": "^5.15.20",
-                "@mui/styles": "^6.1.6",
                 "@types/react": "^18.3.11",
                 "chalk": "^4.1.0",
                 "codesandbox": "^2.2.3",
@@ -933,114 +932,6 @@
             }
         },
         "node_modules/@mui/styled-engine/node_modules/csstype": {
-            "version": "3.1.3",
-            "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
-            "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
-        },
-        "node_modules/@mui/styles": {
-            "version": "6.1.6",
-            "resolved": "https://registry.npmjs.org/@mui/styles/-/styles-6.1.6.tgz",
-            "integrity": "sha512-2cGEUMi4kYNskrg2Upe0bR3Th2/e4j3Vd6R2lIMksBDivJH9o+nkwLjtf91KUOhKZ4BReCDVDC398dbOs+Ygdw==",
-            "dependencies": {
-                "@babel/runtime": "^7.26.0",
-                "@emotion/hash": "^0.9.2",
-                "@mui/private-theming": "^6.1.6",
-                "@mui/types": "^7.2.19",
-                "@mui/utils": "^6.1.6",
-                "clsx": "^2.1.1",
-                "csstype": "^3.1.3",
-                "hoist-non-react-statics": "^3.3.2",
-                "jss": "^10.10.0",
-                "jss-plugin-camel-case": "^10.10.0",
-                "jss-plugin-default-unit": "^10.10.0",
-                "jss-plugin-global": "^10.10.0",
-                "jss-plugin-nested": "^10.10.0",
-                "jss-plugin-props-sort": "^10.10.0",
-                "jss-plugin-rule-value-function": "^10.10.0",
-                "jss-plugin-vendor-prefixer": "^10.10.0",
-                "prop-types": "^15.8.1"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/mui-org"
-            },
-            "peerDependencies": {
-                "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
-                "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
-            },
-            "peerDependenciesMeta": {
-                "@types/react": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/@mui/styles/node_modules/@mui/private-theming": {
-            "version": "6.1.6",
-            "resolved": "https://registry.npmjs.org/@mui/private-theming/-/private-theming-6.1.6.tgz",
-            "integrity": "sha512-ioAiFckaD/fJSnTrUMWgjl9HYBWt7ixCh7zZw7gDZ+Tae7NuprNV6QJK95EidDT7K0GetR2rU3kAeIR61Myttw==",
-            "dependencies": {
-                "@babel/runtime": "^7.26.0",
-                "@mui/utils": "^6.1.6",
-                "prop-types": "^15.8.1"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/mui-org"
-            },
-            "peerDependencies": {
-                "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
-                "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
-            },
-            "peerDependenciesMeta": {
-                "@types/react": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/@mui/styles/node_modules/@mui/utils": {
-            "version": "6.1.6",
-            "resolved": "https://registry.npmjs.org/@mui/utils/-/utils-6.1.6.tgz",
-            "integrity": "sha512-sBS6D9mJECtELASLM+18WUcXF6RH3zNxBRFeyCRg8wad6NbyNrdxLuwK+Ikvc38sTZwBzAz691HmSofLqHd9sQ==",
-            "dependencies": {
-                "@babel/runtime": "^7.26.0",
-                "@mui/types": "^7.2.19",
-                "@types/prop-types": "^15.7.13",
-                "clsx": "^2.1.1",
-                "prop-types": "^15.8.1",
-                "react-is": "^18.3.1"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/mui-org"
-            },
-            "peerDependencies": {
-                "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
-                "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
-            },
-            "peerDependenciesMeta": {
-                "@types/react": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/@mui/styles/node_modules/clsx": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
-            "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
-            "engines": {
-                "node": ">=6"
-            }
-        },
-        "node_modules/@mui/styles/node_modules/csstype": {
             "version": "3.1.3",
             "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
             "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
@@ -3130,15 +3021,6 @@
             "dependencies": {
                 "line-diff": "^2.0.1",
                 "loader-utils": "^1.2.3"
-            }
-        },
-        "node_modules/css-vendor": {
-            "version": "2.0.8",
-            "resolved": "https://registry.npmjs.org/css-vendor/-/css-vendor-2.0.8.tgz",
-            "integrity": "sha512-x9Aq0XTInxrkuFeHKbYC7zWY8ai7qJ04Kxd9MnvbC1uO5DagxoHQjm4JvG+vCdXOoFtCjbL2XSZfxmoYa9uQVQ==",
-            "dependencies": {
-                "@babel/runtime": "^7.8.3",
-                "is-in-browser": "^1.0.2"
             }
         },
         "node_modules/cssesc": {
@@ -5505,11 +5387,6 @@
                 "url": "https://github.com/sponsors/typicode"
             }
         },
-        "node_modules/hyphenate-style-name": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/hyphenate-style-name/-/hyphenate-style-name-1.1.0.tgz",
-            "integrity": "sha512-WDC/ui2VVRrz3jOVi+XtjqkDjiVjTtFaAGiW37k6b+ohyQ5wYDOGkvCZa8+H0nx3gyvv0+BST9xuOgIyGQ00gw=="
-        },
         "node_modules/iconv-lite": {
             "version": "0.4.24",
             "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
@@ -5882,11 +5759,6 @@
                 "node": ">=0.10.0"
             }
         },
-        "node_modules/is-in-browser": {
-            "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/is-in-browser/-/is-in-browser-1.1.3.tgz",
-            "integrity": "sha512-FeXIBgG/CPGd/WUxuEyvgGTEfwiG9Z4EKGxjNMRqviiIIfsmgrpnHLffEDdwUHqNva1VEW91o3xBT/m8Elgl9g=="
-        },
         "node_modules/is-installed-globally": {
             "version": "0.1.0",
             "resolved": "https://registry.npmjs.org/is-installed-globally/-/is-installed-globally-0.1.0.tgz",
@@ -6174,93 +6046,6 @@
             "engines": {
                 "node": ">=0.6.0"
             }
-        },
-        "node_modules/jss": {
-            "version": "10.10.0",
-            "resolved": "https://registry.npmjs.org/jss/-/jss-10.10.0.tgz",
-            "integrity": "sha512-cqsOTS7jqPsPMjtKYDUpdFC0AbhYFLTcuGRqymgmdJIeQ8cH7+AgX7YSgQy79wXloZq2VvATYxUOUQEvS1V/Zw==",
-            "dependencies": {
-                "@babel/runtime": "^7.3.1",
-                "csstype": "^3.0.2",
-                "is-in-browser": "^1.1.3",
-                "tiny-warning": "^1.0.2"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/jss"
-            }
-        },
-        "node_modules/jss-plugin-camel-case": {
-            "version": "10.10.0",
-            "resolved": "https://registry.npmjs.org/jss-plugin-camel-case/-/jss-plugin-camel-case-10.10.0.tgz",
-            "integrity": "sha512-z+HETfj5IYgFxh1wJnUAU8jByI48ED+v0fuTuhKrPR+pRBYS2EDwbusU8aFOpCdYhtRc9zhN+PJ7iNE8pAWyPw==",
-            "dependencies": {
-                "@babel/runtime": "^7.3.1",
-                "hyphenate-style-name": "^1.0.3",
-                "jss": "10.10.0"
-            }
-        },
-        "node_modules/jss-plugin-default-unit": {
-            "version": "10.10.0",
-            "resolved": "https://registry.npmjs.org/jss-plugin-default-unit/-/jss-plugin-default-unit-10.10.0.tgz",
-            "integrity": "sha512-SvpajxIECi4JDUbGLefvNckmI+c2VWmP43qnEy/0eiwzRUsafg5DVSIWSzZe4d2vFX1u9nRDP46WCFV/PXVBGQ==",
-            "dependencies": {
-                "@babel/runtime": "^7.3.1",
-                "jss": "10.10.0"
-            }
-        },
-        "node_modules/jss-plugin-global": {
-            "version": "10.10.0",
-            "resolved": "https://registry.npmjs.org/jss-plugin-global/-/jss-plugin-global-10.10.0.tgz",
-            "integrity": "sha512-icXEYbMufiNuWfuazLeN+BNJO16Ge88OcXU5ZDC2vLqElmMybA31Wi7lZ3lf+vgufRocvPj8443irhYRgWxP+A==",
-            "dependencies": {
-                "@babel/runtime": "^7.3.1",
-                "jss": "10.10.0"
-            }
-        },
-        "node_modules/jss-plugin-nested": {
-            "version": "10.10.0",
-            "resolved": "https://registry.npmjs.org/jss-plugin-nested/-/jss-plugin-nested-10.10.0.tgz",
-            "integrity": "sha512-9R4JHxxGgiZhurDo3q7LdIiDEgtA1bTGzAbhSPyIOWb7ZubrjQe8acwhEQ6OEKydzpl8XHMtTnEwHXCARLYqYA==",
-            "dependencies": {
-                "@babel/runtime": "^7.3.1",
-                "jss": "10.10.0",
-                "tiny-warning": "^1.0.2"
-            }
-        },
-        "node_modules/jss-plugin-props-sort": {
-            "version": "10.10.0",
-            "resolved": "https://registry.npmjs.org/jss-plugin-props-sort/-/jss-plugin-props-sort-10.10.0.tgz",
-            "integrity": "sha512-5VNJvQJbnq/vRfje6uZLe/FyaOpzP/IH1LP+0fr88QamVrGJa0hpRRyAa0ea4U/3LcorJfBFVyC4yN2QC73lJg==",
-            "dependencies": {
-                "@babel/runtime": "^7.3.1",
-                "jss": "10.10.0"
-            }
-        },
-        "node_modules/jss-plugin-rule-value-function": {
-            "version": "10.10.0",
-            "resolved": "https://registry.npmjs.org/jss-plugin-rule-value-function/-/jss-plugin-rule-value-function-10.10.0.tgz",
-            "integrity": "sha512-uEFJFgaCtkXeIPgki8ICw3Y7VMkL9GEan6SqmT9tqpwM+/t+hxfMUdU4wQ0MtOiMNWhwnckBV0IebrKcZM9C0g==",
-            "dependencies": {
-                "@babel/runtime": "^7.3.1",
-                "jss": "10.10.0",
-                "tiny-warning": "^1.0.2"
-            }
-        },
-        "node_modules/jss-plugin-vendor-prefixer": {
-            "version": "10.10.0",
-            "resolved": "https://registry.npmjs.org/jss-plugin-vendor-prefixer/-/jss-plugin-vendor-prefixer-10.10.0.tgz",
-            "integrity": "sha512-UY/41WumgjW8r1qMCO8l1ARg7NHnfRVWRhZ2E2m0DMYsr2DD91qIXLyNhiX83hHswR7Wm4D+oDYNC1zWCJWtqg==",
-            "dependencies": {
-                "@babel/runtime": "^7.3.1",
-                "css-vendor": "^2.0.8",
-                "jss": "10.10.0"
-            }
-        },
-        "node_modules/jss/node_modules/csstype": {
-            "version": "3.1.3",
-            "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
-            "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
         },
         "node_modules/kind-of": {
             "version": "6.0.3",
@@ -10565,11 +10350,6 @@
             "engines": {
                 "node": ">=0.10.0"
             }
-        },
-        "node_modules/tiny-warning": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/tiny-warning/-/tiny-warning-1.0.3.tgz",
-            "integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA=="
         },
         "node_modules/tmp": {
             "version": "0.0.33",

--- a/Examples/package.json
+++ b/Examples/package.json
@@ -61,6 +61,7 @@
     "scichart-react": "^0.1.9",
     "socket.io": "^4.5.2",
     "socket.io-client": "^4.7.5",
+    "tss-react": "^4.9.13",
     "websocket-ts": "^1.1.1"
   },
   "devDependencies": {

--- a/Examples/package.json
+++ b/Examples/package.json
@@ -39,7 +39,7 @@
     "@mui/icons-material": "^5.15.20",
     "@mui/lab": "^5.0.0-alpha.170",
     "@mui/material": "^5.15.20",
-    "@mui/styles": "^5.15.21",
+    "@mui/styles": "^6.1.6",
     "@types/react": "^18.3.11",
     "chalk": "^4.1.0",
     "codesandbox": "^2.2.3",

--- a/Examples/package.json
+++ b/Examples/package.json
@@ -39,7 +39,6 @@
     "@mui/icons-material": "^5.15.20",
     "@mui/lab": "^5.0.0-alpha.170",
     "@mui/material": "^5.15.20",
-    "@mui/styles": "^6.1.6",
     "@types/react": "^18.3.11",
     "chalk": "^4.1.0",
     "codesandbox": "^2.2.3",

--- a/Examples/src/components/App.tsx
+++ b/Examples/src/components/App.tsx
@@ -31,7 +31,8 @@ export default function App() {
 
     const selectedFramework = framework;
 
-    const isMedium = useMediaQuery((theme: Theme) => theme.breakpoints.down("md"));
+    // TODO md was changed by migration script.requires verification
+    const isMedium = useMediaQuery((theme: Theme) => theme.breakpoints.down("lg"));
 
     let initialOpenedMenuItems = {
         MENU_ITEMS_FEATURED_APPS_ID: true,

--- a/Examples/src/components/AppRouter/AppRouter.tsx
+++ b/Examples/src/components/AppRouter/AppRouter.tsx
@@ -36,7 +36,7 @@ export default function AppRouter(props: TProps) {
         const ChartComponent = getExampleComponent(currentExample.id);
 
         return (
-            <div className={classes.ExampleWrapperIFrame}>
+            <div className={`${classes.ExampleWrapperIFrame} AnExampleContainer`}>
                 <NoIndexTag />
                 <Routes>
                     {examplePagesKeys.map((key) => {

--- a/Examples/src/components/Examples/BuilderApi/ChartFromJSON/index.tsx
+++ b/Examples/src/components/Examples/BuilderApi/ChartFromJSON/index.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import classes from "../../styles/Examples.module.scss";
+import commonClasses from "../../styles/Examples.module.scss";
 import { ButtonGroup, Button, TextField } from "@mui/material";
 import { Alert, AlertTitle } from "@mui/material";
 import { SciChartReact } from "scichart-react";
@@ -51,7 +51,7 @@ export default function ChartFromJSON() {
     };
 
     return (
-        <div className={classes.ChartWrapper}>
+        <div className={commonClasses.ChartWrapper}>
             <div style={{ display: "flex", flexDirection: "column", height: "100%" }}>
                 <Chart chartConfig={currentChartConfig} />
                 <div style={{ position: "absolute", left: 20, top: 20 }}>
@@ -63,7 +63,7 @@ export default function ChartFromJSON() {
                     )}
                 </div>
                 <div style={{ flexBasis: "50px" }}>
-                    <div className={classes.FormControl}>
+                    <div className={commonClasses.FormControl}>
                         <ButtonGroup size="medium" color="primary" aria-label="small outlined button group">
                             <Button id="eg1" onClick={loadMinimal}>
                                 Simple example
@@ -90,9 +90,12 @@ export default function ChartFromJSON() {
                         onChange={handleChangeJSON}
                     />
                 </div>
-                <div className={[classes.FormControl, classes.AlignRight].join(" ")} style={{ flexBasis: "50px" }}>
+                <div
+                    className={[commonClasses.FormControl, commonClasses.AlignRight].join(" ")}
+                    style={{ flexBasis: "50px" }}
+                >
                     <ButtonGroup size="medium" color="primary" aria-label="small outlined button group">
-                        <Button className={classes.ButtonFilled} id="buildChart" onClick={handleBuild}>
+                        <Button className={commonClasses.ButtonFilled} id="buildChart" onClick={handleBuild}>
                             Apply
                         </Button>
                     </ButtonGroup>

--- a/Examples/src/components/Examples/BuilderApi/CustomTypes/index.tsx
+++ b/Examples/src/components/Examples/BuilderApi/CustomTypes/index.tsx
@@ -1,11 +1,11 @@
 import * as React from "react";
 import { appTheme } from "../../theme";
 import { SciChartReact } from "scichart-react";
-import classes from "../../styles/Examples.module.scss";
+import commonClasses from "../../styles/Examples.module.scss";
 import { drawExample } from "./drawExample";
 
 // React component needed as our examples app is react.
 // SciChart can be used in Angular, Vue, Blazor and vanilla JS! See our Github repo for more info
 export default function ChartComponent() {
-    return <SciChartReact initChart={drawExample} className={classes.ChartWrapper} />;
+    return <SciChartReact initChart={drawExample} className={commonClasses.ChartWrapper} />;
 }

--- a/Examples/src/components/Examples/BuilderApi/FullChart/index.tsx
+++ b/Examples/src/components/Examples/BuilderApi/FullChart/index.tsx
@@ -1,9 +1,9 @@
 import { SciChartReact } from "scichart-react";
-import classes from "../../styles/Examples.module.scss";
+import commonClasses from "../../styles/Examples.module.scss";
 import { drawExample } from "./drawExample";
 
 // React component needed as our examples app is react.
 // SciChart can be used in Angular, Vue, Blazor and vanilla JS! See our Github repo for more info
 export default function ChartComponent() {
-    return <SciChartReact initChart={drawExample} className={classes.ChartWrapper} />;
+    return <SciChartReact initChart={drawExample} className={commonClasses.ChartWrapper} />;
 }

--- a/Examples/src/components/Examples/BuilderApi/SharedData/index.tsx
+++ b/Examples/src/components/Examples/BuilderApi/SharedData/index.tsx
@@ -1,9 +1,9 @@
 import { SciChartReact } from "scichart-react";
-import classes from "../../styles/Examples.module.scss";
+import commonClasses from "../../styles/Examples.module.scss";
 import { drawExample } from "./drawExample";
 
 // React component needed as our examples app is react.
 // SciChart can be used in Angular, Vue, Blazor and vanilla JS! See our Github repo for more info
 export default function ChartComponent() {
-    return <SciChartReact initChart={drawExample} className={classes.ChartWrapper} />;
+    return <SciChartReact initChart={drawExample} className={commonClasses.ChartWrapper} />;
 }

--- a/Examples/src/components/Examples/BuilderApi/SimpleChart/index.tsx
+++ b/Examples/src/components/Examples/BuilderApi/SimpleChart/index.tsx
@@ -1,9 +1,9 @@
 import { SciChartReact } from "scichart-react";
-import classes from "../../styles/Examples.module.scss";
+import commonClasses from "../../styles/Examples.module.scss";
 import { drawExample } from "./drawExample";
 
 // React component needed as our examples app is react.
 // SciChart can be used in Angular, Vue, Blazor and vanilla JS! See our Github repo for more info
 export default function ChartComponent() {
-    return <SciChartReact initChart={drawExample} className={classes.ChartWrapper} />;
+    return <SciChartReact initChart={drawExample} className={commonClasses.ChartWrapper} />;
 }

--- a/Examples/src/components/Examples/Charts2D/Animations/DataAnimation/index.tsx
+++ b/Examples/src/components/Examples/Charts2D/Animations/DataAnimation/index.tsx
@@ -1,5 +1,5 @@
 import { SciChartReact, TResolvedReturnType } from "scichart-react";
-import classes from "../../../styles/Examples.module.scss";
+import commonClasses from "../../../styles/Examples.module.scss";
 import { drawExample } from "./drawExample";
 
 // React component needed as our examples app is react.
@@ -8,7 +8,7 @@ export default function ChartComponent() {
     return (
         <SciChartReact
             initChart={drawExample}
-            className={classes.ChartWrapper}
+            className={commonClasses.ChartWrapper}
             onDelete={(initResult: TResolvedReturnType<typeof drawExample>) => {
                 initResult.controls.stopAnimation();
             }}

--- a/Examples/src/components/Examples/Charts2D/Animations/GenericAnimation/index.tsx
+++ b/Examples/src/components/Examples/Charts2D/Animations/GenericAnimation/index.tsx
@@ -1,9 +1,9 @@
 import { SciChartReact } from "scichart-react";
-import classes from "../../../styles/Examples.module.scss";
+import commonClasses from "../../../styles/Examples.module.scss";
 import { drawExample } from "./drawExample";
 
 // React component needed as our examples app is react.
 // SciChart can be used in Angular, Vue, Blazor and vanilla JS! See our Github repo for more info
 export default function ChartComponent() {
-    return <SciChartReact initChart={drawExample} className={classes.ChartWrapper} />;
+    return <SciChartReact initChart={drawExample} className={commonClasses.ChartWrapper} />;
 }

--- a/Examples/src/components/Examples/Charts2D/Animations/StartupAnimation/index.tsx
+++ b/Examples/src/components/Examples/Charts2D/Animations/StartupAnimation/index.tsx
@@ -1,9 +1,9 @@
 import { SciChartReact } from "scichart-react";
-import classes from "../../../styles/Examples.module.scss";
+import commonClasses from "../../../styles/Examples.module.scss";
 import { drawExample } from "./drawExample";
 
 // React component needed as our examples app is react.
 // SciChart can be used in Angular, Vue, Blazor and vanilla JS! See our Github repo for more info
 export default function ChartComponent() {
-    return <SciChartReact initChart={drawExample} className={classes.ChartWrapper} />;
+    return <SciChartReact initChart={drawExample} className={commonClasses.ChartWrapper} />;
 }

--- a/Examples/src/components/Examples/Charts2D/Animations/StyleAnimation/index.tsx
+++ b/Examples/src/components/Examples/Charts2D/Animations/StyleAnimation/index.tsx
@@ -1,12 +1,12 @@
 import * as React from "react";
 import commonClasses from "../../../styles/Examples.module.scss";
 import { ToggleButton, ToggleButtonGroup } from "@mui/material";
-import { makeStyles } from "@mui/styles";
+import { makeStyles } from "tss-react/mui";
 import { appTheme } from "../../../theme";
 import { SciChartReact, TResolvedReturnType } from "scichart-react";
 import { drawExample } from "./drawExample";
 
-const useStyles = makeStyles((theme) => ({
+const useStyles = makeStyles()((theme) => ({
     flexOuterContainer: {
         width: "100%",
         height: "100%",
@@ -40,7 +40,7 @@ export default function StyleAnimation() {
         controls.animateChartStyle(isStyle1);
     };
 
-    const classes = useStyles();
+    const { classes } = useStyles();
 
     return (
         <div className={commonClasses.ChartWrapper}>

--- a/Examples/src/components/Examples/Charts2D/Animations/StyleAnimation/index.tsx
+++ b/Examples/src/components/Examples/Charts2D/Animations/StyleAnimation/index.tsx
@@ -40,12 +40,12 @@ export default function StyleAnimation() {
         controls.animateChartStyle(isStyle1);
     };
 
-    const localClasses = useStyles();
+    const classes = useStyles();
 
     return (
         <div className={commonClasses.ChartWrapper}>
-            <div className={localClasses.flexOuterContainer}>
-                <div className={localClasses.toolbarRow}>
+            <div className={classes.flexOuterContainer}>
+                <div className={classes.toolbarRow}>
                     <ToggleButtonGroup
                         exclusive
                         value={preset}
@@ -67,7 +67,7 @@ export default function StyleAnimation() {
                         setControls(initResult.controls);
                     }}
                     initChart={drawExample}
-                    className={localClasses.chartArea}
+                    className={classes.chartArea}
                 />
             </div>
         </div>

--- a/Examples/src/components/Examples/Charts2D/Animations/StyleAnimation/index.tsx
+++ b/Examples/src/components/Examples/Charts2D/Animations/StyleAnimation/index.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import classes from "../../../styles/Examples.module.scss";
+import commonClasses from "../../../styles/Examples.module.scss";
 import { ToggleButton, ToggleButtonGroup } from "@mui/material";
 import { makeStyles } from "@mui/styles";
 import { appTheme } from "../../../theme";
@@ -43,7 +43,7 @@ export default function StyleAnimation() {
     const localClasses = useStyles();
 
     return (
-        <div className={classes.ChartWrapper}>
+        <div className={commonClasses.ChartWrapper}>
             <div className={localClasses.flexOuterContainer}>
                 <div className={localClasses.toolbarRow}>
                     <ToggleButtonGroup

--- a/Examples/src/components/Examples/Charts2D/AxisLabelCustomization/ImageLabels/index.tsx
+++ b/Examples/src/components/Examples/Charts2D/AxisLabelCustomization/ImageLabels/index.tsx
@@ -1,5 +1,5 @@
 import { SciChartReact } from "scichart-react";
-import classes from "../../../styles/Examples.module.scss";
+import commonClasses from "../../../styles/Examples.module.scss";
 import { drawExample } from "./drawExample";
 
 import appleLogo from "./images/apple.png";
@@ -39,5 +39,5 @@ const emojiUrls = [
 // React component needed as our examples app is react.
 // SciChart can be used in Angular, Vue, Blazor and vanilla JS! See our Github repo for more info
 export default function ChartComponent() {
-    return <SciChartReact initChart={drawExample(emojiUrls)} className={classes.ChartWrapper} />;
+    return <SciChartReact initChart={drawExample(emojiUrls)} className={commonClasses.ChartWrapper} />;
 }

--- a/Examples/src/components/Examples/Charts2D/AxisLabelCustomization/MultiLineLabels/index.tsx
+++ b/Examples/src/components/Examples/Charts2D/AxisLabelCustomization/MultiLineLabels/index.tsx
@@ -58,7 +58,7 @@ export default function MultiLineLabels() {
         }
     };
 
-    const localClasses = useStyles();
+    const classes = useStyles();
 
     return (
         <>
@@ -73,8 +73,8 @@ export default function MultiLineLabels() {
                     }}
                 />
             </div>
-            <div className={localClasses.flexOuterContainer}>
-                <div className={localClasses.toolbarRow}>
+            <div className={classes.flexOuterContainer}>
+                <div className={classes.toolbarRow}>
                     <ToggleButtonGroup
                         style={{ height: "100px", padding: "10" }}
                         exclusive

--- a/Examples/src/components/Examples/Charts2D/AxisLabelCustomization/MultiLineLabels/index.tsx
+++ b/Examples/src/components/Examples/Charts2D/AxisLabelCustomization/MultiLineLabels/index.tsx
@@ -2,12 +2,12 @@ import { ToggleButton, ToggleButtonGroup } from "@mui/material";
 import * as React from "react";
 import { drawExample } from "./drawExample";
 import { SciChartReact, TResolvedReturnType } from "scichart-react";
-import { makeStyles } from "@mui/styles";
+import { makeStyles } from "tss-react/mui";
 import { TextLabelProvider, SciChartSurface } from "scichart";
 import { appTheme } from "../../../theme";
 import commonClasses from "../../../styles/Examples.module.scss";
 
-const useStyles = makeStyles((theme) => ({
+const useStyles = makeStyles()((theme) => ({
     flexOuterContainer: {
         width: "100%",
         height: "100%",
@@ -58,7 +58,7 @@ export default function MultiLineLabels() {
         }
     };
 
-    const classes = useStyles();
+    const { classes } = useStyles();
 
     return (
         <>

--- a/Examples/src/components/Examples/Charts2D/AxisLabelCustomization/MultiLineLabels/index.tsx
+++ b/Examples/src/components/Examples/Charts2D/AxisLabelCustomization/MultiLineLabels/index.tsx
@@ -5,7 +5,7 @@ import { SciChartReact, TResolvedReturnType } from "scichart-react";
 import { makeStyles } from "@mui/styles";
 import { TextLabelProvider, SciChartSurface } from "scichart";
 import { appTheme } from "../../../theme";
-import classes from "../../../styles/Examples.module.scss";
+import commonClasses from "../../../styles/Examples.module.scss";
 
 const useStyles = makeStyles((theme) => ({
     flexOuterContainer: {
@@ -62,10 +62,10 @@ export default function MultiLineLabels() {
 
     return (
         <>
-            <div className={classes.ChartWrapper} style={{ background: appTheme.DarkIndigo }}>
+            <div className={commonClasses.ChartWrapper} style={{ background: appTheme.DarkIndigo }}>
                 <SciChartReact
                     initChart={drawExample}
-                    className={classes.ChartWrapper}
+                    className={commonClasses.ChartWrapper}
                     onInit={(initResult: TResolvedReturnType<typeof drawExample>) => {
                         const { sciChartSurface, labelProvider } = initResult;
                         labelProviderRef.current = labelProvider;

--- a/Examples/src/components/Examples/Charts2D/AxisLabelCustomization/RotatedLabels/index.tsx
+++ b/Examples/src/components/Examples/Charts2D/AxisLabelCustomization/RotatedLabels/index.tsx
@@ -1,9 +1,9 @@
 import { SciChartReact } from "scichart-react";
-import classes from "../../../styles/Examples.module.scss";
+import commonClasses from "../../../styles/Examples.module.scss";
 import { drawExample } from "./drawExample";
 
 // React component needed as our examples app is react.
 // SciChart can be used in Angular, Vue, Blazor and vanilla JS! See our Github repo for more info
 export default function ChartComponent() {
-    return <SciChartReact initChart={drawExample} className={classes.ChartWrapper} />;
+    return <SciChartReact initChart={drawExample} className={commonClasses.ChartWrapper} />;
 }

--- a/Examples/src/components/Examples/Charts2D/BasicChartTypes/BandSeriesChart/index.tsx
+++ b/Examples/src/components/Examples/Charts2D/BasicChartTypes/BandSeriesChart/index.tsx
@@ -1,9 +1,9 @@
 import { SciChartReact } from "scichart-react";
-import classes from "../../../styles/Examples.module.scss";
+import commonClasses from "../../../styles/Examples.module.scss";
 import { drawExample } from "./drawExample";
 
 // React component needed as our examples app is react.
 // SciChart can be used in Angular, Vue, Blazor and vanilla JS! See our Github repo for more info
 export default function ChartComponent() {
-    return <SciChartReact initChart={drawExample} className={classes.ChartWrapper} />;
+    return <SciChartReact initChart={drawExample} className={commonClasses.ChartWrapper} />;
 }

--- a/Examples/src/components/Examples/Charts2D/BasicChartTypes/BubbleChart/index.tsx
+++ b/Examples/src/components/Examples/Charts2D/BasicChartTypes/BubbleChart/index.tsx
@@ -1,9 +1,9 @@
 import { SciChartReact } from "scichart-react";
-import classes from "../../../styles/Examples.module.scss";
+import commonClasses from "../../../styles/Examples.module.scss";
 import { drawExample } from "./drawExample";
 
 // React component needed as our examples app is react.
 // SciChart can be used in Angular, Vue, Blazor and vanilla JS! See our Github repo for more info
 export default function ChartComponent() {
-    return <SciChartReact initChart={drawExample} className={classes.ChartWrapper} />;
+    return <SciChartReact initChart={drawExample} className={commonClasses.ChartWrapper} />;
 }

--- a/Examples/src/components/Examples/Charts2D/BasicChartTypes/CandlestickChart/index.tsx
+++ b/Examples/src/components/Examples/Charts2D/BasicChartTypes/CandlestickChart/index.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import { SciChartSurface, FastCandlestickRenderableSeries, SciChartOverview, FastOhlcRenderableSeries } from "scichart";
 import { ToggleButton, ToggleButtonGroup } from "@mui/material";
 import { appTheme } from "../../../theme";
-import classes from "../../../styles/Examples.module.scss";
+import commonClasses from "../../../styles/Examples.module.scss";
 import { SciChartReact, SciChartNestedOverview, TResolvedReturnType } from "scichart-react";
 import { drawExample, overviewOptions } from "./drawExample";
 import FormLabel from "@mui/material/FormLabel";
@@ -32,7 +32,7 @@ export default function CandlestickChart() {
 
     return (
         <React.Fragment>
-            <div className={classes.FullHeightChartWrapper} style={{ background: appTheme.DarkIndigo }}>
+            <div className={commonClasses.FullHeightChartWrapper} style={{ background: appTheme.DarkIndigo }}>
                 <ToggleButtonGroup
                     style={{ height: "70px", padding: "10" }}
                     exclusive

--- a/Examples/src/components/Examples/Charts2D/BasicChartTypes/ColumnChart/index.tsx
+++ b/Examples/src/components/Examples/Charts2D/BasicChartTypes/ColumnChart/index.tsx
@@ -1,9 +1,9 @@
 import { SciChartReact } from "scichart-react";
-import classes from "../../../styles/Examples.module.scss";
+import commonClasses from "../../../styles/Examples.module.scss";
 import { drawExample } from "./drawExample";
 
 // React component needed as our examples app is react.
 // SciChart can be used in Angular, Vue, Blazor and vanilla JS! See our Github repo for more info
 export default function ChartComponent() {
-    return <SciChartReact initChart={drawExample} className={classes.ChartWrapper} />;
+    return <SciChartReact initChart={drawExample} className={commonClasses.ChartWrapper} />;
 }

--- a/Examples/src/components/Examples/Charts2D/BasicChartTypes/ContoursChart/index.tsx
+++ b/Examples/src/components/Examples/Charts2D/BasicChartTypes/ContoursChart/index.tsx
@@ -1,10 +1,10 @@
-import classes from "../../../styles/Examples.module.scss";
+import commonClasses from "../../../styles/Examples.module.scss";
 import { SciChartReact } from "scichart-react";
 import { drawExample, drawHeatmapLegend } from "./drawExample";
 
 export default function ContourChart() {
     return (
-        <div className={classes.ChartWrapper}>
+        <div className={commonClasses.ChartWrapper}>
             <SciChartReact initChart={drawExample} style={{ width: "100%", height: "100%" }} />
             <SciChartReact
                 initChart={drawHeatmapLegend}

--- a/Examples/src/components/Examples/Charts2D/BasicChartTypes/DigitalBandSeriesChart/index.tsx
+++ b/Examples/src/components/Examples/Charts2D/BasicChartTypes/DigitalBandSeriesChart/index.tsx
@@ -1,9 +1,9 @@
 import { SciChartReact } from "scichart-react";
-import classes from "../../../styles/Examples.module.scss";
+import commonClasses from "../../../styles/Examples.module.scss";
 import { drawExample } from "./drawExample";
 
 // React component needed as our examples app is react.
 // SciChart can be used in Angular, Vue, Blazor and vanilla JS! See our Github repo for more info
 export default function ChartComponent() {
-    return <SciChartReact initChart={drawExample} className={classes.ChartWrapper} />;
+    return <SciChartReact initChart={drawExample} className={commonClasses.ChartWrapper} />;
 }

--- a/Examples/src/components/Examples/Charts2D/BasicChartTypes/DigitalLineChart/index.tsx
+++ b/Examples/src/components/Examples/Charts2D/BasicChartTypes/DigitalLineChart/index.tsx
@@ -1,9 +1,9 @@
 import { SciChartReact } from "scichart-react";
-import classes from "../../../styles/Examples.module.scss";
+import commonClasses from "../../../styles/Examples.module.scss";
 import { drawExample } from "./drawExample";
 
 // React component needed as our examples app is react.
 // SciChart can be used in Angular, Vue, Blazor and vanilla JS! See our Github repo for more info
 export default function ChartComponent() {
-    return <SciChartReact initChart={drawExample} className={classes.ChartWrapper} />;
+    return <SciChartReact initChart={drawExample} className={commonClasses.ChartWrapper} />;
 }

--- a/Examples/src/components/Examples/Charts2D/BasicChartTypes/DigitalMountainChart/index.tsx
+++ b/Examples/src/components/Examples/Charts2D/BasicChartTypes/DigitalMountainChart/index.tsx
@@ -1,9 +1,9 @@
 import { SciChartReact } from "scichart-react";
-import classes from "../../../styles/Examples.module.scss";
+import commonClasses from "../../../styles/Examples.module.scss";
 import { drawExample } from "./drawExample";
 
 // React component needed as our examples app is react.
 // SciChart can be used in Angular, Vue, Blazor and vanilla JS! See our Github repo for more info
 export default function ChartComponent() {
-    return <SciChartReact initChart={drawExample} className={classes.ChartWrapper} />;
+    return <SciChartReact initChart={drawExample} className={commonClasses.ChartWrapper} />;
 }

--- a/Examples/src/components/Examples/Charts2D/BasicChartTypes/DonutChart/index.tsx
+++ b/Examples/src/components/Examples/Charts2D/BasicChartTypes/DonutChart/index.tsx
@@ -1,11 +1,11 @@
 import { SciChartReact } from "scichart-react";
 import { appTheme } from "../../../theme";
-import classes from "../../../styles/Examples.module.scss";
+import commonClasses from "../../../styles/Examples.module.scss";
 import { drawExample } from "./drawExample";
 
 export default function ChartComponent() {
     return (
-        <div className={classes.ChartWrapper}>
+        <div className={commonClasses.ChartWrapper}>
             <SciChartReact style={{ width: "100%", height: "100%", float: "left" }} initChart={drawExample} />
             {/*Placeholder until we have a proper chart title (soon!)*/}
             <span

--- a/Examples/src/components/Examples/Charts2D/BasicChartTypes/ErrorBarsChart/index.tsx
+++ b/Examples/src/components/Examples/Charts2D/BasicChartTypes/ErrorBarsChart/index.tsx
@@ -1,11 +1,11 @@
 import * as React from "react";
 import { appTheme } from "../../../theme";
 import { SciChartReact } from "scichart-react";
-import classes from "../../../styles/Examples.module.scss";
+import commonClasses from "../../../styles/Examples.module.scss";
 import { drawExample } from "./drawExample";
 
 // React component needed as our examples app is react.
 // SciChart can be used in Angular, Vue, Blazor and vanilla JS! See our Github repo for more info
 export default function ChartComponent() {
-    return <SciChartReact initChart={drawExample} className={classes.ChartWrapper} />;
+    return <SciChartReact initChart={drawExample} className={commonClasses.ChartWrapper} />;
 }

--- a/Examples/src/components/Examples/Charts2D/BasicChartTypes/FanChart/index.tsx
+++ b/Examples/src/components/Examples/Charts2D/BasicChartTypes/FanChart/index.tsx
@@ -1,11 +1,11 @@
 import * as React from "react";
 import { appTheme } from "../../../theme";
 import { SciChartReact } from "scichart-react";
-import classes from "../../../styles/Examples.module.scss";
+import commonClasses from "../../../styles/Examples.module.scss";
 import { drawExample } from "./drawExample";
 
 // React component needed as our examples app is react.
 // SciChart can be used in Angular, Vue, Blazor and vanilla JS! See our Github repo for more info
 export default function ChartComponent() {
-    return <SciChartReact initChart={drawExample} className={classes.ChartWrapper} />;
+    return <SciChartReact initChart={drawExample} className={commonClasses.ChartWrapper} />;
 }

--- a/Examples/src/components/Examples/Charts2D/BasicChartTypes/HeatmapChart/index.tsx
+++ b/Examples/src/components/Examples/Charts2D/BasicChartTypes/HeatmapChart/index.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import classes from "../../../styles/Examples.module.scss";
+import commonClasses from "../../../styles/Examples.module.scss";
 import { Button } from "@mui/material";
 import { appTheme } from "../../../theme";
 import { makeStyles } from "@mui/styles";
@@ -37,7 +37,7 @@ export default function HeatmapChart() {
     const localClasses = useStyles();
 
     return (
-        <div className={classes.ChartWrapper}>
+        <div className={commonClasses.ChartWrapper}>
             <div className={localClasses.flexOuterContainer}>
                 <div className={localClasses.toolbarRow}>
                     <Button onClick={() => controlsRef.current.startDemo()} style={{ color: appTheme.ForegroundColor }}>

--- a/Examples/src/components/Examples/Charts2D/BasicChartTypes/HeatmapChart/index.tsx
+++ b/Examples/src/components/Examples/Charts2D/BasicChartTypes/HeatmapChart/index.tsx
@@ -2,12 +2,12 @@ import * as React from "react";
 import commonClasses from "../../../styles/Examples.module.scss";
 import { Button } from "@mui/material";
 import { appTheme } from "../../../theme";
-import { makeStyles } from "@mui/styles";
+import { makeStyles } from "tss-react/mui";
 import { SciChartReact, TResolvedReturnType } from "scichart-react";
 import { drawExample, drawHeatmapLegend } from "./drawExample";
 
 // Styles for layout of the toolbar / chart area
-const useStyles = makeStyles((theme) => ({
+const useStyles = makeStyles()((theme) => ({
     flexOuterContainer: {
         width: "100%",
         height: "100%",
@@ -34,7 +34,7 @@ export default function HeatmapChart() {
     });
     const [stats, setStats] = React.useState({ xSize: 0, ySize: 0, fps: 0 });
 
-    const classes = useStyles();
+    const { classes } = useStyles();
 
     return (
         <div className={commonClasses.ChartWrapper}>

--- a/Examples/src/components/Examples/Charts2D/BasicChartTypes/HeatmapChart/index.tsx
+++ b/Examples/src/components/Examples/Charts2D/BasicChartTypes/HeatmapChart/index.tsx
@@ -34,12 +34,12 @@ export default function HeatmapChart() {
     });
     const [stats, setStats] = React.useState({ xSize: 0, ySize: 0, fps: 0 });
 
-    const localClasses = useStyles();
+    const classes = useStyles();
 
     return (
         <div className={commonClasses.ChartWrapper}>
-            <div className={localClasses.flexOuterContainer}>
-                <div className={localClasses.toolbarRow}>
+            <div className={classes.flexOuterContainer}>
+                <div className={classes.toolbarRow}>
                     <Button onClick={() => controlsRef.current.startDemo()} style={{ color: appTheme.ForegroundColor }}>
                         Start
                     </Button>
@@ -51,7 +51,7 @@ export default function HeatmapChart() {
                     </span>
                     <span style={{ margin: 12 }}>FPS: {stats.fps.toFixed(0)}</span>
                 </div>
-                <div className={localClasses.chartArea} style={{ position: "relative" }}>
+                <div className={classes.chartArea} style={{ position: "relative" }}>
                     <SciChartReact
                         initChart={drawExample}
                         style={{ width: "100%", height: "100%" }}

--- a/Examples/src/components/Examples/Charts2D/BasicChartTypes/ImpulseChart/index.tsx
+++ b/Examples/src/components/Examples/Charts2D/BasicChartTypes/ImpulseChart/index.tsx
@@ -1,11 +1,11 @@
 import * as React from "react";
 import { appTheme } from "../../../theme";
 import { SciChartReact } from "scichart-react";
-import classes from "../../../styles/Examples.module.scss";
+import commonClasses from "../../../styles/Examples.module.scss";
 import { drawExample } from "./drawExample";
 
 // React component needed as our examples app is react.
 // SciChart can be used in Angular, Vue, Blazor and vanilla JS! See our Github repo for more info
 export default function ChartComponent() {
-    return <SciChartReact initChart={drawExample} className={classes.ChartWrapper} />;
+    return <SciChartReact initChart={drawExample} className={commonClasses.ChartWrapper} />;
 }

--- a/Examples/src/components/Examples/Charts2D/BasicChartTypes/LineChart/index.tsx
+++ b/Examples/src/components/Examples/Charts2D/BasicChartTypes/LineChart/index.tsx
@@ -1,4 +1,4 @@
-import { makeStyles } from "@mui/styles";
+import { makeStyles } from "tss-react/mui";
 import * as React from "react";
 import { SciChartSurface } from "scichart";
 import commonClasses from "../../../styles/Examples.module.scss";
@@ -7,7 +7,7 @@ import { SciChartReact } from "scichart-react";
 import { getChartsInitializationAPI } from "./drawExample";
 
 // Styles for the 3x3 grid
-const useStyles = makeStyles((theme) => ({
+const useStyles = makeStyles()((theme) => ({
     flexOuterContainer: {
         width: "100%",
         height: "100%",
@@ -36,7 +36,7 @@ const useStyles = makeStyles((theme) => ({
 export default function LineChart() {
     const [chartsInitializationAPI] = React.useState(getChartsInitializationAPI);
 
-    const classes = useStyles();
+    const { classes } = useStyles();
 
     return (
         <div className={commonClasses.ChartWrapper} style={{ aspectRatio: "3 / 2" }}>

--- a/Examples/src/components/Examples/Charts2D/BasicChartTypes/LineChart/index.tsx
+++ b/Examples/src/components/Examples/Charts2D/BasicChartTypes/LineChart/index.tsx
@@ -1,7 +1,7 @@
 import { makeStyles } from "@mui/styles";
 import * as React from "react";
 import { SciChartSurface } from "scichart";
-import classes from "../../../styles/Examples.module.scss";
+import commonClasses from "../../../styles/Examples.module.scss";
 import { appTheme } from "../../../theme";
 import { SciChartReact } from "scichart-react";
 import { getChartsInitializationAPI } from "./drawExample";
@@ -39,7 +39,7 @@ export default function LineChart() {
     const localClasses = useStyles();
 
     return (
-        <div className={classes.ChartWrapper} style={{ aspectRatio: "3 / 2" }}>
+        <div className={commonClasses.ChartWrapper} style={{ aspectRatio: "3 / 2" }}>
             <div className={localClasses.flexOuterContainer}>
                 <div className={localClasses.flexContainerRow}>
                     <SciChartReact

--- a/Examples/src/components/Examples/Charts2D/BasicChartTypes/LineChart/index.tsx
+++ b/Examples/src/components/Examples/Charts2D/BasicChartTypes/LineChart/index.tsx
@@ -36,51 +36,36 @@ const useStyles = makeStyles((theme) => ({
 export default function LineChart() {
     const [chartsInitializationAPI] = React.useState(getChartsInitializationAPI);
 
-    const localClasses = useStyles();
+    const classes = useStyles();
 
     return (
         <div className={commonClasses.ChartWrapper} style={{ aspectRatio: "3 / 2" }}>
-            <div className={localClasses.flexOuterContainer}>
-                <div className={localClasses.flexContainerRow}>
-                    <SciChartReact
-                        initChart={chartsInitializationAPI.initJustLineCharts}
-                        className={localClasses.item}
-                    />
-                    <SciChartReact
-                        initChart={chartsInitializationAPI.initDigitalLineCharts}
-                        className={localClasses.item}
-                    />
+            <div className={classes.flexOuterContainer}>
+                <div className={classes.flexContainerRow}>
+                    <SciChartReact initChart={chartsInitializationAPI.initJustLineCharts} className={classes.item} />
+                    <SciChartReact initChart={chartsInitializationAPI.initDigitalLineCharts} className={classes.item} />
                     <SciChartReact
                         initChart={chartsInitializationAPI.initTooltipsOnLineCharts}
-                        className={localClasses.item}
+                        className={classes.item}
                     />
                 </div>
-                <div className={localClasses.flexContainerRow}>
-                    <SciChartReact
-                        initChart={chartsInitializationAPI.initDashedLineCharts}
-                        className={localClasses.item}
-                    />
+                <div className={classes.flexContainerRow}>
+                    <SciChartReact initChart={chartsInitializationAPI.initDashedLineCharts} className={classes.item} />
                     <SciChartReact
                         initChart={chartsInitializationAPI.initPalettedLineCharts}
-                        className={localClasses.item}
+                        className={classes.item}
                     />
-                    <SciChartReact
-                        initChart={chartsInitializationAPI.initHoveredLineCharts}
-                        className={localClasses.item}
-                    />
+                    <SciChartReact initChart={chartsInitializationAPI.initHoveredLineCharts} className={classes.item} />
                 </div>
-                <div className={localClasses.flexContainerRow}>
-                    <SciChartReact
-                        initChart={chartsInitializationAPI.initGapsInLineCharts}
-                        className={localClasses.item}
-                    />
+                <div className={classes.flexContainerRow}>
+                    <SciChartReact initChart={chartsInitializationAPI.initGapsInLineCharts} className={classes.item} />
                     <SciChartReact
                         initChart={chartsInitializationAPI.initVerticalLineCharts}
-                        className={localClasses.item}
+                        className={classes.item}
                     />
                     <SciChartReact
                         initChart={chartsInitializationAPI.initThresholdedLineCharts}
-                        className={localClasses.item}
+                        className={classes.item}
                     />
                 </div>
             </div>

--- a/Examples/src/components/Examples/Charts2D/BasicChartTypes/MountainChart/index.tsx
+++ b/Examples/src/components/Examples/Charts2D/BasicChartTypes/MountainChart/index.tsx
@@ -1,11 +1,11 @@
 import * as React from "react";
 import { appTheme } from "../../../theme";
 import { SciChartReact } from "scichart-react";
-import classes from "../../../styles/Examples.module.scss";
+import commonClasses from "../../../styles/Examples.module.scss";
 import { drawExample } from "./drawExample";
 
 // React component needed as our examples app is react.
 // SciChart can be used in Angular, Vue, Blazor and vanilla JS! See our Github repo for more info
 export default function ChartComponent() {
-    return <SciChartReact initChart={drawExample} className={classes.ChartWrapper} />;
+    return <SciChartReact initChart={drawExample} className={commonClasses.ChartWrapper} />;
 }

--- a/Examples/src/components/Examples/Charts2D/BasicChartTypes/NonUniformHeatmapChart/index.tsx
+++ b/Examples/src/components/Examples/Charts2D/BasicChartTypes/NonUniformHeatmapChart/index.tsx
@@ -1,11 +1,11 @@
 import * as React from "react";
 import { appTheme } from "../../../theme";
 import { SciChartReact } from "scichart-react";
-import classes from "../../../styles/Examples.module.scss";
+import commonClasses from "../../../styles/Examples.module.scss";
 import { drawExample } from "./drawExample";
 
 // React component needed as our examples app is react.
 // SciChart can be used in Angular, Vue, Blazor and vanilla JS! See our Github repo for more info
 export default function ChartComponent() {
-    return <SciChartReact initChart={drawExample} className={classes.ChartWrapper} />;
+    return <SciChartReact initChart={drawExample} className={commonClasses.ChartWrapper} />;
 }

--- a/Examples/src/components/Examples/Charts2D/BasicChartTypes/OhlcChart/index.tsx
+++ b/Examples/src/components/Examples/Charts2D/BasicChartTypes/OhlcChart/index.tsx
@@ -1,11 +1,11 @@
 import * as React from "react";
 import { appTheme } from "../../../theme";
 import { SciChartReact } from "scichart-react";
-import classes from "../../../styles/Examples.module.scss";
+import commonClasses from "../../../styles/Examples.module.scss";
 import { drawExample } from "./drawExample";
 
 // React component needed as our examples app is react.
 // SciChart can be used in Angular, Vue, Blazor and vanilla JS! See our Github repo for more info
 export default function ChartComponent() {
-    return <SciChartReact initChart={drawExample} className={classes.ChartWrapper} />;
+    return <SciChartReact initChart={drawExample} className={commonClasses.ChartWrapper} />;
 }

--- a/Examples/src/components/Examples/Charts2D/BasicChartTypes/PieChart/index.tsx
+++ b/Examples/src/components/Examples/Charts2D/BasicChartTypes/PieChart/index.tsx
@@ -1,12 +1,12 @@
 import * as React from "react";
-import classes from "../../../styles/Examples.module.scss";
+import commonClasses from "../../../styles/Examples.module.scss";
 import { appTheme } from "../../../theme";
 import { SciChartReact } from "scichart-react";
 import { drawExample } from "./drawExample";
 
 export default function ChartComponent() {
     return (
-        <div className={classes.ChartWrapper}>
+        <div className={commonClasses.ChartWrapper}>
             <SciChartReact style={{ width: "100%", height: "100%", float: "left" }} initChart={drawExample} />
             {/*Placeholder until we have a proper chart title (soon!)*/}
             <span

--- a/Examples/src/components/Examples/Charts2D/BasicChartTypes/RealTimeMountainChart/index.tsx
+++ b/Examples/src/components/Examples/Charts2D/BasicChartTypes/RealTimeMountainChart/index.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import { SciChartReact, TResolvedReturnType } from "scichart-react";
-import classes from "../../../styles/Examples.module.scss";
+import commonClasses from "../../../styles/Examples.module.scss";
 import { drawExample } from "./drawExample";
 
 // React component needed as our examples app is react.
@@ -9,7 +9,7 @@ export default function ChartComponent() {
     return (
         <SciChartReact
             initChart={drawExample}
-            className={classes.ChartWrapper}
+            className={commonClasses.ChartWrapper}
             onInit={(initResult: TResolvedReturnType<typeof drawExample>) => {
                 initResult.controls.handleStart();
             }}

--- a/Examples/src/components/Examples/Charts2D/BasicChartTypes/ScatterChart/index.tsx
+++ b/Examples/src/components/Examples/Charts2D/BasicChartTypes/ScatterChart/index.tsx
@@ -1,11 +1,11 @@
 import * as React from "react";
 import { appTheme } from "../../../theme";
 import { SciChartReact } from "scichart-react";
-import classes from "../../../styles/Examples.module.scss";
+import commonClasses from "../../../styles/Examples.module.scss";
 import { drawExample } from "./drawExample";
 
 // React component needed as our examples app is react.
 // SciChart can be used in Angular, Vue, Blazor and vanilla JS! See our Github repo for more info
 export default function ChartComponent() {
-    return <SciChartReact initChart={drawExample} className={classes.ChartWrapper} />;
+    return <SciChartReact initChart={drawExample} className={commonClasses.ChartWrapper} />;
 }

--- a/Examples/src/components/Examples/Charts2D/BasicChartTypes/SmoothStackedMountainChart/index.tsx
+++ b/Examples/src/components/Examples/Charts2D/BasicChartTypes/SmoothStackedMountainChart/index.tsx
@@ -3,10 +3,10 @@ import commonClasses from "../../../styles/Examples.module.scss";
 import { appTheme } from "../../../theme";
 import { ToggleButton, ToggleButtonGroup } from "@mui/material";
 import { SciChartReact, SciChartNestedOverview, TResolvedReturnType } from "scichart-react";
-import { makeStyles } from "@mui/styles";
+import { makeStyles } from "tss-react/mui";
 import { SciChartSurface, StackedMountainCollection } from "scichart";
 import { drawExample } from "./drawExample";
-const useStyles = makeStyles((theme) => ({
+const useStyles = makeStyles()((theme) => ({
     flexOuterContainer: {
         width: "100%",
         height: "100%",
@@ -40,7 +40,7 @@ export default function SmoothStackedMountainChart() {
         }
     };
 
-    const classes = useStyles();
+    const { classes } = useStyles();
     return (
         <div className={commonClasses.ChartWrapper}>
             <div className={classes.flexOuterContainer}>

--- a/Examples/src/components/Examples/Charts2D/BasicChartTypes/SmoothStackedMountainChart/index.tsx
+++ b/Examples/src/components/Examples/Charts2D/BasicChartTypes/SmoothStackedMountainChart/index.tsx
@@ -40,12 +40,12 @@ export default function SmoothStackedMountainChart() {
         }
     };
 
-    const localClasses = useStyles();
+    const classes = useStyles();
     return (
         <div className={commonClasses.ChartWrapper}>
-            <div className={localClasses.flexOuterContainer}>
+            <div className={classes.flexOuterContainer}>
                 <ToggleButtonGroup
-                    className={localClasses.toolbarRow}
+                    className={classes.toolbarRow}
                     exclusive
                     value={use100PercentStackedMode}
                     onChange={handleUsePercentage}
@@ -61,7 +61,7 @@ export default function SmoothStackedMountainChart() {
                     </ToggleButton>
                 </ToggleButtonGroup>
                 <SciChartReact
-                    className={localClasses.chartArea}
+                    className={classes.chartArea}
                     initChart={drawExample}
                     onInit={(initResult: TResolvedReturnType<typeof drawExample>) => {
                         controlsRef.current = initResult.controls;

--- a/Examples/src/components/Examples/Charts2D/BasicChartTypes/SmoothStackedMountainChart/index.tsx
+++ b/Examples/src/components/Examples/Charts2D/BasicChartTypes/SmoothStackedMountainChart/index.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import classes from "../../../styles/Examples.module.scss";
+import commonClasses from "../../../styles/Examples.module.scss";
 import { appTheme } from "../../../theme";
 import { ToggleButton, ToggleButtonGroup } from "@mui/material";
 import { SciChartReact, SciChartNestedOverview, TResolvedReturnType } from "scichart-react";
@@ -42,7 +42,7 @@ export default function SmoothStackedMountainChart() {
 
     const localClasses = useStyles();
     return (
-        <div className={classes.ChartWrapper}>
+        <div className={commonClasses.ChartWrapper}>
             <div className={localClasses.flexOuterContainer}>
                 <ToggleButtonGroup
                     className={localClasses.toolbarRow}

--- a/Examples/src/components/Examples/Charts2D/BasicChartTypes/SplineBandSeriesChart/index.tsx
+++ b/Examples/src/components/Examples/Charts2D/BasicChartTypes/SplineBandSeriesChart/index.tsx
@@ -1,10 +1,10 @@
 import * as React from "react";
 import { SciChartReact } from "scichart-react";
-import classes from "../../../styles/Examples.module.scss";
+import commonClasses from "../../../styles/Examples.module.scss";
 import { drawExample } from "./drawExample";
 
 // React component needed as our examples app is react.
 // SciChart can be used in Angular, Vue, Blazor and vanilla JS! See our Github repo for more info
 export default function ChartComponent() {
-    return <SciChartReact initChart={drawExample} className={classes.ChartWrapper} />;
+    return <SciChartReact initChart={drawExample} className={commonClasses.ChartWrapper} />;
 }

--- a/Examples/src/components/Examples/Charts2D/BasicChartTypes/SplineLineChart/index.tsx
+++ b/Examples/src/components/Examples/Charts2D/BasicChartTypes/SplineLineChart/index.tsx
@@ -1,10 +1,10 @@
 import * as React from "react";
 import { SciChartReact } from "scichart-react";
-import classes from "../../../styles/Examples.module.scss";
+import commonClasses from "../../../styles/Examples.module.scss";
 import { drawExample } from "./drawExample";
 
 // React component needed as our examples app is react.
 // SciChart can be used in Angular, Vue, Blazor and vanilla JS! See our Github repo for more info
 export default function ChartComponent() {
-    return <SciChartReact initChart={drawExample} className={classes.ChartWrapper} />;
+    return <SciChartReact initChart={drawExample} className={commonClasses.ChartWrapper} />;
 }

--- a/Examples/src/components/Examples/Charts2D/BasicChartTypes/SplineMountainChart/index.tsx
+++ b/Examples/src/components/Examples/Charts2D/BasicChartTypes/SplineMountainChart/index.tsx
@@ -1,11 +1,11 @@
 import * as React from "react";
 import { appTheme } from "../../../theme";
 import { SciChartReact } from "scichart-react";
-import classes from "../../../styles/Examples.module.scss";
+import commonClasses from "../../../styles/Examples.module.scss";
 import { drawExample } from "./drawExample";
 
 // React component needed as our examples app is react.
 // SciChart can be used in Angular, Vue, Blazor and vanilla JS! See our Github repo for more info
 export default function ChartComponent() {
-    return <SciChartReact initChart={drawExample} className={classes.ChartWrapper} />;
+    return <SciChartReact initChart={drawExample} className={commonClasses.ChartWrapper} />;
 }

--- a/Examples/src/components/Examples/Charts2D/BasicChartTypes/StackedColumnChart/index.tsx
+++ b/Examples/src/components/Examples/Charts2D/BasicChartTypes/StackedColumnChart/index.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { useState } from "react";
 import { appTheme } from "../../../theme";
-import classes from "../../../styles/Examples.module.scss";
+import commonClasses from "../../../styles/Examples.module.scss";
 import { ToggleButton, ToggleButtonGroup } from "@mui/material";
 import { makeStyles } from "@mui/styles";
 import { drawExample } from "./drawExample";
@@ -50,7 +50,7 @@ export default function StackedColumnChart() {
 
     const localClasses = useStyles();
     return (
-        <div className={classes.ChartWrapper}>
+        <div className={commonClasses.ChartWrapper}>
             <div className={localClasses.flexOuterContainer}>
                 <div className={localClasses.toolbarRow}>
                     <ToggleButtonGroup

--- a/Examples/src/components/Examples/Charts2D/BasicChartTypes/StackedColumnChart/index.tsx
+++ b/Examples/src/components/Examples/Charts2D/BasicChartTypes/StackedColumnChart/index.tsx
@@ -3,11 +3,11 @@ import { useState } from "react";
 import { appTheme } from "../../../theme";
 import commonClasses from "../../../styles/Examples.module.scss";
 import { ToggleButton, ToggleButtonGroup } from "@mui/material";
-import { makeStyles } from "@mui/styles";
+import { makeStyles } from "tss-react/mui";
 import { drawExample } from "./drawExample";
 import { SciChartReact, TResolvedReturnType } from "scichart-react";
 
-const useStyles = makeStyles((theme) => ({
+const useStyles = makeStyles()((theme) => ({
     flexOuterContainer: {
         width: "100%",
         height: "100%",
@@ -48,7 +48,7 @@ export default function StackedColumnChart() {
         controls.toggleDataLabels(areDataLabelsVisible);
     };
 
-    const classes = useStyles();
+    const { classes } = useStyles();
     return (
         <div className={commonClasses.ChartWrapper}>
             <div className={classes.flexOuterContainer}>

--- a/Examples/src/components/Examples/Charts2D/BasicChartTypes/StackedColumnChart/index.tsx
+++ b/Examples/src/components/Examples/Charts2D/BasicChartTypes/StackedColumnChart/index.tsx
@@ -48,13 +48,13 @@ export default function StackedColumnChart() {
         controls.toggleDataLabels(areDataLabelsVisible);
     };
 
-    const localClasses = useStyles();
+    const classes = useStyles();
     return (
         <div className={commonClasses.ChartWrapper}>
-            <div className={localClasses.flexOuterContainer}>
-                <div className={localClasses.toolbarRow}>
+            <div className={classes.flexOuterContainer}>
+                <div className={classes.toolbarRow}>
                     <ToggleButtonGroup
-                        className={localClasses.toolbarRow}
+                        className={classes.toolbarRow}
                         exclusive
                         size="small"
                         value={use100PercentStackedMode}
@@ -70,7 +70,7 @@ export default function StackedColumnChart() {
                         </ToggleButton>
                     </ToggleButtonGroup>
 
-                    <ToggleButtonGroup style={{ marginLeft: "auto" }} className={localClasses.toolbarRow} size="small">
+                    <ToggleButtonGroup style={{ marginLeft: "auto" }} className={classes.toolbarRow} size="small">
                         <ToggleButton
                             value={areDataLabelsVisible}
                             style={{ color: appTheme.ForegroundColor }}
@@ -82,7 +82,7 @@ export default function StackedColumnChart() {
                 </div>
                 <SciChartReact
                     initChart={drawExample}
-                    className={localClasses.chartArea}
+                    className={classes.chartArea}
                     onInit={(initResult: TResolvedReturnType<typeof drawExample>) => {
                         setControls(initResult.controls);
                     }}

--- a/Examples/src/components/Examples/Charts2D/BasicChartTypes/StackedColumnSideBySide/index.tsx
+++ b/Examples/src/components/Examples/Charts2D/BasicChartTypes/StackedColumnSideBySide/index.tsx
@@ -1,11 +1,11 @@
 import * as React from "react";
 import { appTheme } from "../../../theme";
 import { SciChartReact } from "scichart-react";
-import classes from "../../../styles/Examples.module.scss";
+import commonClasses from "../../../styles/Examples.module.scss";
 import { drawExample } from "./drawExample";
 
 // React component needed as our examples app is react.
 // SciChart can be used in Angular, Vue, Blazor and vanilla JS! See our Github repo for more info
 export default function ChartComponent() {
-    return <SciChartReact initChart={drawExample} className={classes.ChartWrapper} />;
+    return <SciChartReact initChart={drawExample} className={commonClasses.ChartWrapper} />;
 }

--- a/Examples/src/components/Examples/Charts2D/BasicChartTypes/StackedMountainChart/index.tsx
+++ b/Examples/src/components/Examples/Charts2D/BasicChartTypes/StackedMountainChart/index.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import classes from "../../../styles/Examples.module.scss";
+import commonClasses from "../../../styles/Examples.module.scss";
 import { appTheme } from "../../../theme";
 import { ToggleButton, ToggleButtonGroup } from "@mui/material";
 import { makeStyles } from "@mui/styles";
@@ -46,7 +46,7 @@ export default function StackedMountainChart() {
 
     const localClasses = useStyles();
     return (
-        <div className={classes.ChartWrapper}>
+        <div className={commonClasses.ChartWrapper}>
             <div className={localClasses.flexOuterContainer}>
                 <ToggleButtonGroup
                     className={localClasses.toolbarRow}

--- a/Examples/src/components/Examples/Charts2D/BasicChartTypes/StackedMountainChart/index.tsx
+++ b/Examples/src/components/Examples/Charts2D/BasicChartTypes/StackedMountainChart/index.tsx
@@ -2,12 +2,12 @@ import * as React from "react";
 import commonClasses from "../../../styles/Examples.module.scss";
 import { appTheme } from "../../../theme";
 import { ToggleButton, ToggleButtonGroup } from "@mui/material";
-import { makeStyles } from "@mui/styles";
+import { makeStyles } from "tss-react/mui";
 import { SciChartSurface, StackedMountainCollection } from "scichart";
 import { SciChartReact, TResolvedReturnType } from "scichart-react";
 import { drawExample } from "./drawExample";
 
-const useStyles = makeStyles((theme) => ({
+const useStyles = makeStyles()((theme) => ({
     flexOuterContainer: {
         width: "100%",
         height: "100%",
@@ -44,7 +44,7 @@ export default function StackedMountainChart() {
         }
     };
 
-    const classes = useStyles();
+    const { classes } = useStyles();
     return (
         <div className={commonClasses.ChartWrapper}>
             <div className={classes.flexOuterContainer}>

--- a/Examples/src/components/Examples/Charts2D/BasicChartTypes/StackedMountainChart/index.tsx
+++ b/Examples/src/components/Examples/Charts2D/BasicChartTypes/StackedMountainChart/index.tsx
@@ -44,12 +44,12 @@ export default function StackedMountainChart() {
         }
     };
 
-    const localClasses = useStyles();
+    const classes = useStyles();
     return (
         <div className={commonClasses.ChartWrapper}>
-            <div className={localClasses.flexOuterContainer}>
+            <div className={classes.flexOuterContainer}>
                 <ToggleButtonGroup
-                    className={localClasses.toolbarRow}
+                    className={classes.toolbarRow}
                     exclusive
                     value={use100PercentStackedMode}
                     onChange={handleUsePercentage}
@@ -66,7 +66,7 @@ export default function StackedMountainChart() {
                 </ToggleButtonGroup>
                 <SciChartReact
                     initChart={drawExample}
-                    className={localClasses.chartArea}
+                    className={classes.chartArea}
                     onInit={(initResult: TResolvedReturnType<typeof drawExample>) => {
                         const { sciChartSurface, stackedMountainCollection } = initResult;
                         stackedMountainCollectionRef.current = stackedMountainCollection;

--- a/Examples/src/components/Examples/Charts2D/BasicChartTypes/TextSeriesChart/index.tsx
+++ b/Examples/src/components/Examples/Charts2D/BasicChartTypes/TextSeriesChart/index.tsx
@@ -1,11 +1,11 @@
 import * as React from "react";
 import { appTheme } from "../../../theme";
 import { SciChartReact } from "scichart-react";
-import classes from "../../../styles/Examples.module.scss";
+import commonClasses from "../../../styles/Examples.module.scss";
 import { drawExample } from "./drawExample";
 
 // React component needed as our examples app is react.
 // SciChart can be used in Angular, Vue, Blazor and vanilla JS! See our Github repo for more info
 export default function ChartComponent() {
-    return <SciChartReact initChart={drawExample} className={classes.ChartWrapper} />;
+    return <SciChartReact initChart={drawExample} className={commonClasses.ChartWrapper} />;
 }

--- a/Examples/src/components/Examples/Charts2D/ChartAnnotations/AnnotationLayers/index.tsx
+++ b/Examples/src/components/Examples/Charts2D/ChartAnnotations/AnnotationLayers/index.tsx
@@ -1,11 +1,11 @@
 import * as React from "react";
 import { appTheme } from "../../../theme";
 import { SciChartReact } from "scichart-react";
-import classes from "../../../styles/Examples.module.scss";
+import commonClasses from "../../../styles/Examples.module.scss";
 import { drawExample } from "./drawExample";
 
 // React component needed as our examples app is react.
 // SciChart can be used in Angular, Vue, Blazor and vanilla JS! See our Github repo for more info
 export default function ChartComponent() {
-    return <SciChartReact initChart={drawExample} className={classes.ChartWrapper} />;
+    return <SciChartReact initChart={drawExample} className={commonClasses.ChartWrapper} />;
 }

--- a/Examples/src/components/Examples/Charts2D/ChartAnnotations/AnnotationsAreEasy/index.tsx
+++ b/Examples/src/components/Examples/Charts2D/ChartAnnotations/AnnotationsAreEasy/index.tsx
@@ -1,12 +1,12 @@
 import * as React from "react";
 import { appTheme } from "../../../theme";
 import { SciChartReact } from "scichart-react";
-import classes from "../../../styles/Examples.module.scss";
+import commonClasses from "../../../styles/Examples.module.scss";
 import { drawExample } from "./drawExample";
 import CustomImage from "./scichart-logo-white.png";
 
 // React component needed as our examples app is react.
 // SciChart can be used in Angular, Vue, Blazor and vanilla JS! See our Github repo for more info
 export default function ChartComponent() {
-    return <SciChartReact initChart={drawExample(CustomImage)} className={classes.ChartWrapper} />;
+    return <SciChartReact initChart={drawExample(CustomImage)} className={commonClasses.ChartWrapper} />;
 }

--- a/Examples/src/components/Examples/Charts2D/ChartAnnotations/BackgroundAnnotations/index.tsx
+++ b/Examples/src/components/Examples/Charts2D/ChartAnnotations/BackgroundAnnotations/index.tsx
@@ -1,11 +1,11 @@
 import * as React from "react";
 import { appTheme } from "../../../theme";
 import { SciChartReact } from "scichart-react";
-import classes from "../../../styles/Examples.module.scss";
+import commonClasses from "../../../styles/Examples.module.scss";
 import { drawExample } from "./drawExample";
 
 // React component needed as our examples app is react.
 // SciChart can be used in Angular, Vue, Blazor and vanilla JS! See our Github repo for more info
 export default function ChartComponent() {
-    return <SciChartReact initChart={drawExample} className={classes.ChartWrapper} />;
+    return <SciChartReact initChart={drawExample} className={commonClasses.ChartWrapper} />;
 }

--- a/Examples/src/components/Examples/Charts2D/ChartAnnotations/DragHorizontalThreshold/index.tsx
+++ b/Examples/src/components/Examples/Charts2D/ChartAnnotations/DragHorizontalThreshold/index.tsx
@@ -1,11 +1,11 @@
 import * as React from "react";
 import { appTheme } from "../../../theme";
 import { SciChartReact } from "scichart-react";
-import classes from "../../../styles/Examples.module.scss";
+import commonClasses from "../../../styles/Examples.module.scss";
 import { drawExample } from "./drawExample";
 
 // React component needed as our examples app is react.
 // SciChart can be used in Angular, Vue, Blazor and vanilla JS! See our Github repo for more info
 export default function ChartComponent() {
-    return <SciChartReact initChart={drawExample} className={classes.ChartWrapper} />;
+    return <SciChartReact initChart={drawExample} className={commonClasses.ChartWrapper} />;
 }

--- a/Examples/src/components/Examples/Charts2D/ChartAnnotations/EditableAnnotations/index.tsx
+++ b/Examples/src/components/Examples/Charts2D/ChartAnnotations/EditableAnnotations/index.tsx
@@ -1,11 +1,11 @@
 import * as React from "react";
 import { appTheme } from "../../../theme";
 import { SciChartReact } from "scichart-react";
-import classes from "../../../styles/Examples.module.scss";
+import commonClasses from "../../../styles/Examples.module.scss";
 import { drawExample } from "./drawExample";
 import SciChartImage from "./scichart-logo-white.png";
 // React component needed as our examples app is react.
 // SciChart can be used in Angular, Vue, Blazor and vanilla JS! See our Github repo for more info
 export default function ChartComponent() {
-    return <SciChartReact initChart={drawExample(SciChartImage)} className={classes.ChartWrapper} />;
+    return <SciChartReact initChart={drawExample(SciChartImage)} className={commonClasses.ChartWrapper} />;
 }

--- a/Examples/src/components/Examples/Charts2D/ChartAnnotations/TradeMarkers/index.tsx
+++ b/Examples/src/components/Examples/Charts2D/ChartAnnotations/TradeMarkers/index.tsx
@@ -1,11 +1,11 @@
 import * as React from "react";
 import { appTheme } from "../../../theme";
 import { SciChartReact } from "scichart-react";
-import classes from "../../../styles/Examples.module.scss";
+import commonClasses from "../../../styles/Examples.module.scss";
 import { drawExample } from "./drawExample";
 
 // React component needed as our examples app is react.
 // SciChart can be used in Angular, Vue, Blazor and vanilla JS! See our Github repo for more info
 export default function ChartComponent() {
-    return <SciChartReact initChart={drawExample} className={classes.ChartWrapper} />;
+    return <SciChartReact initChart={drawExample} className={commonClasses.ChartWrapper} />;
 }

--- a/Examples/src/components/Examples/Charts2D/CreateStockCharts/DepthChart/index.tsx
+++ b/Examples/src/components/Examples/Charts2D/CreateStockCharts/DepthChart/index.tsx
@@ -1,11 +1,11 @@
 import * as React from "react";
 import { appTheme } from "../../../theme";
 import { SciChartReact } from "scichart-react";
-import classes from "../../../styles/Examples.module.scss";
+import commonClasses from "../../../styles/Examples.module.scss";
 import { drawExample } from "./drawExample";
 
 // React component needed as our examples app is react.
 // SciChart can be used in Angular, Vue, Blazor and vanilla JS! See our Github repo for more info
 export default function ChartComponent() {
-    return <SciChartReact initChart={drawExample} className={classes.ChartWrapper} />;
+    return <SciChartReact initChart={drawExample} className={commonClasses.ChartWrapper} />;
 }

--- a/Examples/src/components/Examples/Charts2D/CreateStockCharts/MultiPaneStockCharts/index.tsx
+++ b/Examples/src/components/Examples/Charts2D/CreateStockCharts/MultiPaneStockCharts/index.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { appTheme } from "../../../theme";
 import { SciChartGroup, SciChartReact } from "scichart-react";
-import classes from "../../../styles/Examples.module.scss";
+import commonClasses from "../../../styles/Examples.module.scss";
 import { getChartsInitializationAPI } from "./drawExample";
 import { SciChartSurface } from "scichart";
 
@@ -10,7 +10,7 @@ export default function MultiPaneStockCharts() {
     const [mainChart, setMainChart] = React.useState<SciChartSurface>();
 
     return (
-        <div className={classes.ChartWrapper}>
+        <div className={commonClasses.ChartWrapper}>
             <SciChartGroup onInit={chartsInitializationAPI.configureAfterInit}>
                 <div style={{ display: "flex", flexDirection: "column", height: "100%" }}>
                     {/*The panel hosting the price chart*/}

--- a/Examples/src/components/Examples/Charts2D/CreateStockCharts/RealtimeTickingStockCharts/index.tsx
+++ b/Examples/src/components/Examples/Charts2D/CreateStockCharts/RealtimeTickingStockCharts/index.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { IDeletable } from "scichart";
 import { ToggleButton, ToggleButtonGroup } from "@mui/material";
-import classes from "../../../styles/Examples.module.scss";
+import commonClasses from "../../../styles/Examples.module.scss";
 import { createCandlestickChart, sciChartOverview } from "./createCandlestickChart";
 import { SciChartReact, SciChartNestedOverview, TResolvedReturnType } from "scichart-react";
 import { binanceSocketClient, TRealtimePriceBar } from "./binanceSocketClient";
@@ -101,7 +101,7 @@ export default function RealtimeTickingStockCharts() {
 
     return (
         <React.Fragment>
-            <div className={classes.FullHeightChartWrapper} style={{ background: appTheme.DarkIndigo }}>
+            <div className={commonClasses.FullHeightChartWrapper} style={{ background: appTheme.DarkIndigo }}>
                 <ToggleButtonGroup
                     style={{ height: "70px", padding: "10" }}
                     exclusive

--- a/Examples/src/components/Examples/Charts2D/CreateStockCharts/SubChartStockCharts/index.tsx
+++ b/Examples/src/components/Examples/Charts2D/CreateStockCharts/SubChartStockCharts/index.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import classes from "../../../styles/Examples.module.scss";
+import commonClasses from "../../../styles/Examples.module.scss";
 import { FinChartLegendModifier, IFinanceLegendModifierOptions } from "./FinChartLegendModifier";
 
 import {
@@ -611,7 +611,7 @@ export default function SubChartStockCharts() {
 
     return (
         <div
-            className={classes.ChartsWrapper}
+            className={commonClasses.ChartsWrapper}
             id={containerId2}
             style={{
                 position: "relative",

--- a/Examples/src/components/Examples/Charts2D/CreateStockCharts/UserAnnotatedStockChart/index.tsx
+++ b/Examples/src/components/Examples/Charts2D/CreateStockCharts/UserAnnotatedStockChart/index.tsx
@@ -12,11 +12,13 @@ import { appTheme } from "../../../theme";
 import commonClasses from "../../../styles/Examples.module.scss";
 import { drawExample, IChartControls } from "./drawExample";
 import { Button, ButtonGroup, MenuItem, Select, TextField } from "@mui/material";
+
 // If you want to keep using makeStyles:
-import { makeStyles } from "@mui/styles";
+import { makeStyles } from "tss-react/mui";
+
 import { SciChartReact, TResolvedReturnType } from "scichart-react";
 
-const useStyles = makeStyles((theme) => ({
+const useStyles = makeStyles()((theme) => ({
     flexOuterContainer: {
         width: "100%",
         height: "100%",
@@ -87,7 +89,7 @@ export default function UserAnnotatedStockChart() {
         controlsRef.current.resetChart();
     };
 
-    const classes = useStyles();
+    const { classes } = useStyles();
 
     return (
         <React.Fragment>

--- a/Examples/src/components/Examples/Charts2D/CreateStockCharts/UserAnnotatedStockChart/index.tsx
+++ b/Examples/src/components/Examples/Charts2D/CreateStockCharts/UserAnnotatedStockChart/index.tsx
@@ -87,13 +87,13 @@ export default function UserAnnotatedStockChart() {
         controlsRef.current.resetChart();
     };
 
-    const localClasses = useStyles();
+    const classes = useStyles();
 
     return (
         <React.Fragment>
             <div className={commonClasses.ChartWrapper}>
-                <div className={localClasses.flexOuterContainer}>
-                    <div className={localClasses.toolbarRow}>
+                <div className={classes.flexOuterContainer}>
+                    <div className={classes.toolbarRow}>
                         <ToggleButtonGroup
                             style={{ height: "70px", padding: "10" }}
                             exclusive
@@ -167,7 +167,7 @@ export default function UserAnnotatedStockChart() {
                         </ButtonGroup>
                     </div>
                     <SciChartReact
-                        className={localClasses.chartArea}
+                        className={classes.chartArea}
                         initChart={drawExample}
                         onInit={({ sciChartSurface, controls }: TResolvedReturnType<typeof drawExample>) => {
                             sciChartSurfaceRef.current = sciChartSurface;

--- a/Examples/src/components/Examples/Charts2D/CreateStockCharts/UserAnnotatedStockChart/index.tsx
+++ b/Examples/src/components/Examples/Charts2D/CreateStockCharts/UserAnnotatedStockChart/index.tsx
@@ -9,7 +9,7 @@ import {
 } from "scichart";
 import { ToggleButton, ToggleButtonGroup } from "@mui/material";
 import { appTheme } from "../../../theme";
-import classes from "../../../styles/Examples.module.scss";
+import commonClasses from "../../../styles/Examples.module.scss";
 import { drawExample, IChartControls } from "./drawExample";
 import { Button, ButtonGroup, MenuItem, Select, TextField } from "@mui/material";
 // If you want to keep using makeStyles:
@@ -91,7 +91,7 @@ export default function UserAnnotatedStockChart() {
 
     return (
         <React.Fragment>
-            <div className={classes.ChartWrapper}>
+            <div className={commonClasses.ChartWrapper}>
                 <div className={localClasses.flexOuterContainer}>
                     <div className={localClasses.toolbarRow}>
                         <ToggleButtonGroup

--- a/Examples/src/components/Examples/Charts2D/Filters/CustomFilters/index.tsx
+++ b/Examples/src/components/Examples/Charts2D/Filters/CustomFilters/index.tsx
@@ -1,12 +1,12 @@
 import * as React from "react";
 import { appTheme } from "../../../theme";
-import classes from "../../../styles/Examples.module.scss";
+import commonClasses from "../../../styles/Examples.module.scss";
 import { SciChartReact, TResolvedReturnType } from "scichart-react";
 import { drawExample } from "./drawExample";
 
 export default function ChartComponent() {
     return (
-        <div className={classes.ChartWrapper}>
+        <div className={commonClasses.ChartWrapper}>
             <SciChartReact
                 style={{ width: "100%", height: "100%", float: "left" }}
                 initChart={drawExample}

--- a/Examples/src/components/Examples/Charts2D/Filters/PercentageChange/index.tsx
+++ b/Examples/src/components/Examples/Charts2D/Filters/PercentageChange/index.tsx
@@ -1,13 +1,13 @@
 import { ToggleButton, ToggleButtonGroup, ToggleButtonGroupProps } from "@mui/material";
 import * as React from "react";
-import { makeStyles } from "@mui/styles";
+import { makeStyles } from "tss-react/mui";
 import commonClasses from "../../../styles/Examples.module.scss";
 import { SciChartReact, TResolvedReturnType } from "scichart-react";
 import { SciChartSurface } from "scichart";
 import { appTheme } from "../../../theme";
 import { drawExample } from "./drawExample";
 
-const useStyles = makeStyles((theme) => ({
+const useStyles = makeStyles()((theme) => ({
     flexOuterContainer: {
         width: "100%",
         height: "100%",
@@ -40,7 +40,7 @@ export default function PercentageChange() {
         }
     };
 
-    const classes = useStyles();
+    const { classes } = useStyles();
     return (
         <div className={commonClasses.ChartWrapper}>
             <div className={classes.flexOuterContainer}>

--- a/Examples/src/components/Examples/Charts2D/Filters/PercentageChange/index.tsx
+++ b/Examples/src/components/Examples/Charts2D/Filters/PercentageChange/index.tsx
@@ -1,7 +1,7 @@
 import { ToggleButton, ToggleButtonGroup, ToggleButtonGroupProps } from "@mui/material";
 import * as React from "react";
 import { makeStyles } from "@mui/styles";
-import classes from "../../../styles/Examples.module.scss";
+import commonClasses from "../../../styles/Examples.module.scss";
 import { SciChartReact, TResolvedReturnType } from "scichart-react";
 import { SciChartSurface } from "scichart";
 import { appTheme } from "../../../theme";
@@ -42,7 +42,7 @@ export default function PercentageChange() {
 
     const localClasses = useStyles();
     return (
-        <div className={classes.ChartWrapper}>
+        <div className={commonClasses.ChartWrapper}>
             <div className={localClasses.flexOuterContainer}>
                 <ToggleButtonGroup
                     className={localClasses.toolbarRow}
@@ -64,7 +64,7 @@ export default function PercentageChange() {
                 <SciChartReact
                     key={chartKey} // Change the key to force re-render
                     initChart={(rootElement) => drawExample(rootElement, usePercentage)}
-                    className={classes.ChartWrapper}
+                    className={commonClasses.ChartWrapper}
                 />
             </div>
         </div>

--- a/Examples/src/components/Examples/Charts2D/Filters/PercentageChange/index.tsx
+++ b/Examples/src/components/Examples/Charts2D/Filters/PercentageChange/index.tsx
@@ -40,12 +40,12 @@ export default function PercentageChange() {
         }
     };
 
-    const localClasses = useStyles();
+    const classes = useStyles();
     return (
         <div className={commonClasses.ChartWrapper}>
-            <div className={localClasses.flexOuterContainer}>
+            <div className={classes.flexOuterContainer}>
                 <ToggleButtonGroup
-                    className={localClasses.toolbarRow}
+                    className={classes.toolbarRow}
                     exclusive
                     value={usePercentage}
                     onChange={handleUsePercentage}

--- a/Examples/src/components/Examples/Charts2D/Filters/TrendMARatio/index.tsx
+++ b/Examples/src/components/Examples/Charts2D/Filters/TrendMARatio/index.tsx
@@ -1,11 +1,11 @@
 import * as React from "react";
 import { appTheme } from "../../../theme";
 import { SciChartReact } from "scichart-react";
-import classes from "../../../styles/Examples.module.scss";
+import commonClasses from "../../../styles/Examples.module.scss";
 import { drawExample } from "./drawExample";
 
 // React component needed as our examples app is react.
 // SciChart can be used in Angular, Vue, Blazor and vanilla JS! See our Github repo for more info
 export default function ChartComponent() {
-    return <SciChartReact initChart={drawExample} className={classes.ChartWrapper} />;
+    return <SciChartReact initChart={drawExample} className={commonClasses.ChartWrapper} />;
 }

--- a/Examples/src/components/Examples/Charts2D/Legends/ChartLegendsAPI/index.tsx
+++ b/Examples/src/components/Examples/Charts2D/Legends/ChartLegendsAPI/index.tsx
@@ -94,14 +94,14 @@ export default function ChartLegendsAPI() {
             flex: "auto",
         },
     }));
-    const localClasses = useStyles();
+    const classes = useStyles();
 
     return (
         <React.Fragment>
             <div className={commonClasses.FullHeightChartWrapper} style={{ background: appTheme.DarkIndigo }}>
-                <div className={localClasses.flexContainer}>
+                <div className={classes.flexContainer}>
                     {/*The toolbar is here*/}
-                    <div className={localClasses.toolbar}>
+                    <div className={classes.toolbar}>
                         Show Legend?
                         <Checkbox checked={showLegendValue} onChange={handleChangeShowLegend} />
                         Show Visibility Checkboxes?
@@ -111,7 +111,7 @@ export default function ChartLegendsAPI() {
                         <label id="sciChartPlacement-label">
                             Legend Placement
                             <select
-                                className={localClasses.combobox}
+                                className={classes.combobox}
                                 id="sciChartPlacement"
                                 value={placementValue}
                                 onChange={handleChangePlacement}
@@ -126,7 +126,7 @@ export default function ChartLegendsAPI() {
                         <label id="sciChartPlacement-label">
                             Legend Orientation
                             <select
-                                className={localClasses.combobox}
+                                className={classes.combobox}
                                 id="sciChartOrientation"
                                 value={orientationValue}
                                 onChange={handleChangeOrientation}

--- a/Examples/src/components/Examples/Charts2D/Legends/ChartLegendsAPI/index.tsx
+++ b/Examples/src/components/Examples/Charts2D/Legends/ChartLegendsAPI/index.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import Checkbox from "@mui/material/Checkbox";
 import commonClasses from "../../../styles/Examples.module.scss";
-import { makeStyles } from "@mui/styles";
+import { makeStyles } from "tss-react/mui";
 import { ELegendOrientation, ELegendPlacement, LegendModifier, SciChartSurface } from "scichart";
 import { appTheme } from "../../../theme";
 import { drawExample } from "./drawExample";
@@ -69,7 +69,7 @@ export default function ChartLegendsAPI() {
         }
     };
 
-    const useStyles = makeStyles((theme) => ({
+    const useStyles = makeStyles()((theme) => ({
         flexContainer: {
             display: "flex",
             flexDirection: "column",
@@ -94,7 +94,7 @@ export default function ChartLegendsAPI() {
             flex: "auto",
         },
     }));
-    const classes = useStyles();
+    const { classes } = useStyles();
 
     return (
         <React.Fragment>

--- a/Examples/src/components/Examples/Charts2D/Legends/ChartLegendsAPI/index.tsx
+++ b/Examples/src/components/Examples/Charts2D/Legends/ChartLegendsAPI/index.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import Checkbox from "@mui/material/Checkbox";
-import classes from "../../../styles/Examples.module.scss";
+import commonClasses from "../../../styles/Examples.module.scss";
 import { makeStyles } from "@mui/styles";
 import { ELegendOrientation, ELegendPlacement, LegendModifier, SciChartSurface } from "scichart";
 import { appTheme } from "../../../theme";
@@ -98,7 +98,7 @@ export default function ChartLegendsAPI() {
 
     return (
         <React.Fragment>
-            <div className={classes.FullHeightChartWrapper} style={{ background: appTheme.DarkIndigo }}>
+            <div className={commonClasses.FullHeightChartWrapper} style={{ background: appTheme.DarkIndigo }}>
                 <div className={localClasses.flexContainer}>
                     {/*The toolbar is here*/}
                     <div className={localClasses.toolbar}>
@@ -143,7 +143,7 @@ export default function ChartLegendsAPI() {
                         <SciChartReact
                             initChart={drawExample}
                             style={{ width: "100%", height: "100%" }}
-                            className={classes.ChartWrapper}
+                            className={commonClasses.ChartWrapper}
                             onInit={(initResult: TResolvedReturnType<typeof drawExample>) => {
                                 const { sciChartSurface, legendModifier } = initResult;
                                 legendModifierRef.current = legendModifier;

--- a/Examples/src/components/Examples/Charts2D/ModifyAxisBehavior/CentralAxes/index.tsx
+++ b/Examples/src/components/Examples/Charts2D/ModifyAxisBehavior/CentralAxes/index.tsx
@@ -1,11 +1,11 @@
 import * as React from "react";
 import { appTheme } from "../../../theme";
 import { SciChartReact } from "scichart-react";
-import classes from "../../../styles/Examples.module.scss";
+import commonClasses from "../../../styles/Examples.module.scss";
 import { drawExample } from "./drawExample";
 
 // React component needed as our examples app is react.
 // SciChart can be used in Angular, Vue, Blazor and vanilla JS! See our Github repo for more info
 export default function ChartComponent() {
-    return <SciChartReact initChart={drawExample} className={classes.ChartWrapper} />;
+    return <SciChartReact initChart={drawExample} className={commonClasses.ChartWrapper} />;
 }

--- a/Examples/src/components/Examples/Charts2D/ModifyAxisBehavior/DrawBehindAxes/index.tsx
+++ b/Examples/src/components/Examples/Charts2D/ModifyAxisBehavior/DrawBehindAxes/index.tsx
@@ -2,7 +2,7 @@ import { ToggleButton, ToggleButtonGroup } from "@mui/material";
 import * as React from "react";
 import { SciChartSurface } from "scichart";
 import { appTheme } from "../../../theme";
-import classes from "../../../styles/Examples.module.scss";
+import commonClasses from "../../../styles/Examples.module.scss";
 import { drawExample } from "./drawExample";
 import { SciChartReact, TResolvedReturnType } from "scichart-react";
 
@@ -23,11 +23,11 @@ export default function DrawBehindAxes() {
     };
 
     return (
-        <div className={classes.ChartWrapper} style={{ background: appTheme.DarkIndigo }}>
+        <div className={commonClasses.ChartWrapper} style={{ background: appTheme.DarkIndigo }}>
             <SciChartReact
                 initChart={drawExample}
                 style={{ height: "calc(100% - 100px)", width: "100%" }}
-                className={classes.ChartWrapper}
+                className={commonClasses.ChartWrapper}
                 onInit={(initResult: TResolvedReturnType<typeof drawExample>) => {
                     const { sciChartSurface } = initResult;
                     sciChartSurfaceRef.current = sciChartSurface;

--- a/Examples/src/components/Examples/Charts2D/ModifyAxisBehavior/LogarithmicAxis/index.tsx
+++ b/Examples/src/components/Examples/Charts2D/ModifyAxisBehavior/LogarithmicAxis/index.tsx
@@ -2,12 +2,12 @@ import * as React from "react";
 import { appTheme } from "../../../theme";
 import commonClasses from "../../../styles/Examples.module.scss";
 import { ToggleButton, ToggleButtonGroup } from "@mui/material";
-import { makeStyles } from "@mui/styles";
+import { makeStyles } from "tss-react/mui";
 import { SciChartReact, TResolvedReturnType } from "scichart-react";
 import { AxisBase2D, LogarithmicAxis, NumericAxis, SciChartSurface } from "scichart";
 import { drawExample } from "./drawExample";
 
-const useStyles = makeStyles((theme) => ({
+const useStyles = makeStyles()((theme) => ({
     flexOuterContainer: {
         width: "100%",
         height: "100%",
@@ -85,7 +85,7 @@ export default function LogarithmicAxisExample() {
         sciChartSurface.zoomExtents();
     };
 
-    const classes = useStyles();
+    const { classes } = useStyles();
 
     return (
         <div className={commonClasses.ChartWrapper}>

--- a/Examples/src/components/Examples/Charts2D/ModifyAxisBehavior/LogarithmicAxis/index.tsx
+++ b/Examples/src/components/Examples/Charts2D/ModifyAxisBehavior/LogarithmicAxis/index.tsx
@@ -85,12 +85,12 @@ export default function LogarithmicAxisExample() {
         sciChartSurface.zoomExtents();
     };
 
-    const localClasses = useStyles();
+    const classes = useStyles();
 
     return (
         <div className={commonClasses.ChartWrapper}>
-            <div className={localClasses.flexOuterContainer}>
-                <div className={localClasses.toolbarRow}>
+            <div className={classes.flexOuterContainer}>
+                <div className={classes.toolbarRow}>
                     <ToggleButtonGroup
                         exclusive
                         value={preset}
@@ -112,7 +112,7 @@ export default function LogarithmicAxisExample() {
                 </div>
                 <SciChartReact
                     initChart={drawExample}
-                    className={localClasses.chartArea}
+                    className={classes.chartArea}
                     onInit={(initResult: TResolvedReturnType<typeof drawExample>) => {
                         const { sciChartSurface } = initResult;
                         sciChartSurfaceRef.current = sciChartSurface;

--- a/Examples/src/components/Examples/Charts2D/ModifyAxisBehavior/LogarithmicAxis/index.tsx
+++ b/Examples/src/components/Examples/Charts2D/ModifyAxisBehavior/LogarithmicAxis/index.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import { appTheme } from "../../../theme";
-import classes from "../../../styles/Examples.module.scss";
+import commonClasses from "../../../styles/Examples.module.scss";
 import { ToggleButton, ToggleButtonGroup } from "@mui/material";
 import { makeStyles } from "@mui/styles";
 import { SciChartReact, TResolvedReturnType } from "scichart-react";
@@ -88,7 +88,7 @@ export default function LogarithmicAxisExample() {
     const localClasses = useStyles();
 
     return (
-        <div className={classes.ChartWrapper}>
+        <div className={commonClasses.ChartWrapper}>
             <div className={localClasses.flexOuterContainer}>
                 <div className={localClasses.toolbarRow}>
                     <ToggleButtonGroup

--- a/Examples/src/components/Examples/Charts2D/ModifyAxisBehavior/MultipleXAxes/index.tsx
+++ b/Examples/src/components/Examples/Charts2D/ModifyAxisBehavior/MultipleXAxes/index.tsx
@@ -1,11 +1,11 @@
 import * as React from "react";
 import { appTheme } from "../../../theme";
 import { SciChartReact } from "scichart-react";
-import classes from "../../../styles/Examples.module.scss";
+import commonClasses from "../../../styles/Examples.module.scss";
 import { drawExample } from "./drawExample";
 
 // React component needed as our examples app is react.
 // SciChart can be used in Angular, Vue, Blazor and vanilla JS! See our Github repo for more info
 export default function ChartComponent() {
-    return <SciChartReact initChart={drawExample} className={classes.ChartWrapper} />;
+    return <SciChartReact initChart={drawExample} className={commonClasses.ChartWrapper} />;
 }

--- a/Examples/src/components/Examples/Charts2D/ModifyAxisBehavior/SecondaryYAxes/index.tsx
+++ b/Examples/src/components/Examples/Charts2D/ModifyAxisBehavior/SecondaryYAxes/index.tsx
@@ -1,11 +1,11 @@
 import * as React from "react";
 import { appTheme } from "../../../theme";
 import { SciChartReact } from "scichart-react";
-import classes from "../../../styles/Examples.module.scss";
+import commonClasses from "../../../styles/Examples.module.scss";
 import { drawExample } from "./drawExample";
 
 // React component needed as our examples app is react.
 // SciChart can be used in Angular, Vue, Blazor and vanilla JS! See our Github repo for more info
 export default function ChartComponent() {
-    return <SciChartReact initChart={drawExample} className={classes.ChartWrapper} />;
+    return <SciChartReact initChart={drawExample} className={commonClasses.ChartWrapper} />;
 }

--- a/Examples/src/components/Examples/Charts2D/ModifyAxisBehavior/StaticAxis/index.tsx
+++ b/Examples/src/components/Examples/Charts2D/ModifyAxisBehavior/StaticAxis/index.tsx
@@ -3,11 +3,11 @@ import { ToggleButton, ToggleButtonGroup } from "@mui/material";
 import { drawExample } from "./drawExample";
 import { appTheme } from "../../../theme";
 import commonClasses from "../../../styles/Examples.module.scss";
-import { makeStyles } from "@mui/styles";
+import { makeStyles } from "tss-react/mui";
 import { SciChartReact, TResolvedReturnType } from "scichart-react";
 import { Typography } from "@mui/material";
 
-const useStyles = makeStyles(() => ({
+const useStyles = makeStyles()(() => ({
     flexOuterContainer: {
         width: "100%",
         height: "100%",
@@ -35,7 +35,7 @@ export default function ChartComponent() {
 
     const controlsRef = React.useRef<{ toggleStaticAxis: () => void }>();
 
-    const classes = useStyles();
+    const { classes } = useStyles();
     return (
         <>
             <div className={commonClasses.ChartWrapper}>

--- a/Examples/src/components/Examples/Charts2D/ModifyAxisBehavior/StaticAxis/index.tsx
+++ b/Examples/src/components/Examples/Charts2D/ModifyAxisBehavior/StaticAxis/index.tsx
@@ -35,12 +35,12 @@ export default function ChartComponent() {
 
     const controlsRef = React.useRef<{ toggleStaticAxis: () => void }>();
 
-    const localClasses = useStyles();
+    const classes = useStyles();
     return (
         <>
             <div className={commonClasses.ChartWrapper}>
-                <div className={localClasses.flexOuterContainer}>
-                    <div className={localClasses.toolbarRow}>
+                <div className={classes.flexOuterContainer}>
+                    <div className={classes.toolbarRow}>
                         <Typography style={{ color: appTheme.ForegroundColor }}>Primary Axis: </Typography>
                         <ToggleButtonGroup
                             exclusive
@@ -63,7 +63,7 @@ export default function ChartComponent() {
                     </div>
 
                     <SciChartReact
-                        className={localClasses.chartArea}
+                        className={classes.chartArea}
                         initChart={drawExample}
                         onInit={(initResult: TResolvedReturnType<typeof drawExample>) => {
                             controlsRef.current = initResult.controls;

--- a/Examples/src/components/Examples/Charts2D/ModifyAxisBehavior/StaticAxis/index.tsx
+++ b/Examples/src/components/Examples/Charts2D/ModifyAxisBehavior/StaticAxis/index.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import { ToggleButton, ToggleButtonGroup } from "@mui/material";
 import { drawExample } from "./drawExample";
 import { appTheme } from "../../../theme";
-import classes from "../../../styles/Examples.module.scss";
+import commonClasses from "../../../styles/Examples.module.scss";
 import { makeStyles } from "@mui/styles";
 import { SciChartReact, TResolvedReturnType } from "scichart-react";
 import { Typography } from "@mui/material";
@@ -38,7 +38,7 @@ export default function ChartComponent() {
     const localClasses = useStyles();
     return (
         <>
-            <div className={classes.ChartWrapper}>
+            <div className={commonClasses.ChartWrapper}>
                 <div className={localClasses.flexOuterContainer}>
                     <div className={localClasses.toolbarRow}>
                         <Typography style={{ color: appTheme.ForegroundColor }}>Primary Axis: </Typography>

--- a/Examples/src/components/Examples/Charts2D/ModifyAxisBehavior/VerticalCharts/index.tsx
+++ b/Examples/src/components/Examples/Charts2D/ModifyAxisBehavior/VerticalCharts/index.tsx
@@ -1,11 +1,11 @@
 import * as React from "react";
 import { appTheme } from "../../../theme";
 import { SciChartReact } from "scichart-react";
-import classes from "../../../styles/Examples.module.scss";
+import commonClasses from "../../../styles/Examples.module.scss";
 import { drawExample } from "./drawExample";
 
 // React component needed as our examples app is react.
 // SciChart can be used in Angular, Vue, Blazor and vanilla JS! See our Github repo for more info
 export default function ChartComponent() {
-    return <SciChartReact initChart={drawExample} className={classes.ChartWrapper} />;
+    return <SciChartReact initChart={drawExample} className={commonClasses.ChartWrapper} />;
 }

--- a/Examples/src/components/Examples/Charts2D/ModifyAxisBehavior/VerticallyStackedAxes/index.tsx
+++ b/Examples/src/components/Examples/Charts2D/ModifyAxisBehavior/VerticallyStackedAxes/index.tsx
@@ -1,11 +1,11 @@
 import * as React from "react";
 import { appTheme } from "../../../theme";
 import { SciChartReact } from "scichart-react";
-import classes from "../../../styles/Examples.module.scss";
+import commonClasses from "../../../styles/Examples.module.scss";
 import { drawExample } from "./drawExample";
 
 // React component needed as our examples app is react.
 // SciChart can be used in Angular, Vue, Blazor and vanilla JS! See our Github repo for more info
 export default function ChartComponent() {
-    return <SciChartReact initChart={drawExample} className={classes.ChartWrapper} />;
+    return <SciChartReact initChart={drawExample} className={commonClasses.ChartWrapper} />;
 }

--- a/Examples/src/components/Examples/Charts2D/MultiChart/SyncMultiChart/index.tsx
+++ b/Examples/src/components/Examples/Charts2D/MultiChart/SyncMultiChart/index.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { makeStyles } from "@mui/styles";
+import { makeStyles } from "tss-react/mui";
 import { RandomWalkGenerator } from "../../../ExampleData/RandomWalkGenerator";
 import { appTheme } from "../../../theme";
 import commonClasses from "../../../styles/Examples.module.scss";
@@ -181,7 +181,7 @@ type ChartPane = {
 };
 
 // Styles for the 3x3 grid
-const useStyles = makeStyles((theme) => ({
+const useStyles = makeStyles()((theme) => ({
     flexOuterContainer: {
         width: "100%",
         height: "100%",
@@ -244,7 +244,7 @@ export default function SyncMultiChart() {
         chartPanes.length = 0;
     };
 
-    const classes = useStyles();
+    const { classes } = useStyles();
 
     React.useEffect(() => {
         const chartInitializationPromise = Promise.all([addChart(0), addChart(1), addChart(2), addChart(3)]);

--- a/Examples/src/components/Examples/Charts2D/MultiChart/SyncMultiChart/index.tsx
+++ b/Examples/src/components/Examples/Charts2D/MultiChart/SyncMultiChart/index.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import { makeStyles } from "@mui/styles";
 import { RandomWalkGenerator } from "../../../ExampleData/RandomWalkGenerator";
 import { appTheme } from "../../../theme";
-import classes from "../../../styles/Examples.module.scss";
+import commonClasses from "../../../styles/Examples.module.scss";
 
 import {
     AxisBase2D,
@@ -305,7 +305,7 @@ export default function SyncMultiChart() {
 
     const firstFreePane = chartPanes.find((pane) => !pane.sciChartSurface);
     return (
-        <div className={classes.ChartWrapper}>
+        <div className={commonClasses.ChartWrapper}>
             <div className={localClasses.flexOuterContainer}>
                 <div style={{ width: "100%", height: "100px", flex: "none" }}>
                     <div className={localClasses.chartArea} id={chartPanes[0].divId}></div>

--- a/Examples/src/components/Examples/Charts2D/MultiChart/SyncMultiChart/index.tsx
+++ b/Examples/src/components/Examples/Charts2D/MultiChart/SyncMultiChart/index.tsx
@@ -244,7 +244,7 @@ export default function SyncMultiChart() {
         chartPanes.length = 0;
     };
 
-    const localClasses = useStyles();
+    const classes = useStyles();
 
     React.useEffect(() => {
         const chartInitializationPromise = Promise.all([addChart(0), addChart(1), addChart(2), addChart(3)]);
@@ -306,9 +306,9 @@ export default function SyncMultiChart() {
     const firstFreePane = chartPanes.find((pane) => !pane.sciChartSurface);
     return (
         <div className={commonClasses.ChartWrapper}>
-            <div className={localClasses.flexOuterContainer}>
+            <div className={classes.flexOuterContainer}>
                 <div style={{ width: "100%", height: "100px", flex: "none" }}>
-                    <div className={localClasses.chartArea} id={chartPanes[0].divId}></div>
+                    <div className={classes.chartArea} id={chartPanes[0].divId}></div>
                 </div>
                 {firstFreePane ? (
                     <div
@@ -344,16 +344,13 @@ export default function SyncMultiChart() {
                 {chartPanes
                     .filter((pane) => pane.id > 0)
                     .map((pane) => (
-                        <div
-                            className={pane.sciChartSurface ? localClasses.chartRow : localClasses.emptyRow}
-                            key={pane.id}
-                        >
+                        <div className={pane.sciChartSurface ? classes.chartRow : classes.emptyRow} key={pane.id}>
                             <div
-                                className={pane.sciChartSurface ? localClasses.chartArea : localClasses.emptyRow}
+                                className={pane.sciChartSurface ? classes.chartArea : classes.emptyRow}
                                 id={pane.divId}
                             ></div>
                             {pane.sciChartSurface ? (
-                                <div className={localClasses.toolCol}>
+                                <div className={classes.toolCol}>
                                     <div>
                                         <Button
                                             color="primary"

--- a/Examples/src/components/Examples/Charts2D/StylingAndTheming/CreateACustomTheme/index.tsx
+++ b/Examples/src/components/Examples/Charts2D/StylingAndTheming/CreateACustomTheme/index.tsx
@@ -1,11 +1,11 @@
 import * as React from "react";
 import { appTheme } from "../../../theme";
 import { SciChartReact } from "scichart-react";
-import classes from "../../../styles/Examples.module.scss";
+import commonClasses from "../../../styles/Examples.module.scss";
 import { drawExample } from "./drawExample";
 
 // React component needed as our examples app is react.
 // SciChart can be used in Angular, Vue, Blazor and vanilla JS! See our Github repo for more info
 export default function ChartComponent() {
-    return <SciChartReact initChart={drawExample} className={classes.ChartWrapper} />;
+    return <SciChartReact initChart={drawExample} className={commonClasses.ChartWrapper} />;
 }

--- a/Examples/src/components/Examples/Charts2D/StylingAndTheming/DashedLineStyling/index.tsx
+++ b/Examples/src/components/Examples/Charts2D/StylingAndTheming/DashedLineStyling/index.tsx
@@ -1,11 +1,11 @@
 import * as React from "react";
 import { appTheme } from "../../../theme";
 import { SciChartReact } from "scichart-react";
-import classes from "../../../styles/Examples.module.scss";
+import commonClasses from "../../../styles/Examples.module.scss";
 import { drawExample } from "./drawExample";
 
 // React component needed as our examples app is react.
 // SciChart can be used in Angular, Vue, Blazor and vanilla JS! See our Github repo for more info
 export default function ChartComponent() {
-    return <SciChartReact initChart={drawExample} className={classes.ChartWrapper} />;
+    return <SciChartReact initChart={drawExample} className={commonClasses.ChartWrapper} />;
 }

--- a/Examples/src/components/Examples/Charts2D/StylingAndTheming/DataLabels/index.tsx
+++ b/Examples/src/components/Examples/Charts2D/StylingAndTheming/DataLabels/index.tsx
@@ -1,11 +1,11 @@
 import * as React from "react";
 import { appTheme } from "../../../theme";
 import { SciChartReact } from "scichart-react";
-import classes from "../../../styles/Examples.module.scss";
+import commonClasses from "../../../styles/Examples.module.scss";
 import { drawExample } from "./drawExample";
 
 // React component needed as our examples app is react.
 // SciChart can be used in Angular, Vue, Blazor and vanilla JS! See our Github repo for more info
 export default function ChartComponent() {
-    return <SciChartReact initChart={drawExample} className={classes.ChartWrapper} />;
+    return <SciChartReact initChart={drawExample} className={commonClasses.ChartWrapper} />;
 }

--- a/Examples/src/components/Examples/Charts2D/StylingAndTheming/PerPointColoring/index.tsx
+++ b/Examples/src/components/Examples/Charts2D/StylingAndTheming/PerPointColoring/index.tsx
@@ -1,11 +1,11 @@
 import * as React from "react";
 import { appTheme } from "../../../theme";
 import { SciChartReact } from "scichart-react";
-import classes from "../../../styles/Examples.module.scss";
+import commonClasses from "../../../styles/Examples.module.scss";
 import { drawExample } from "./drawExample";
 
 // React component needed as our examples app is react.
 // SciChart can be used in Angular, Vue, Blazor and vanilla JS! See our Github repo for more info
 export default function ChartComponent() {
-    return <SciChartReact initChart={drawExample} className={classes.ChartWrapper} />;
+    return <SciChartReact initChart={drawExample} className={commonClasses.ChartWrapper} />;
 }

--- a/Examples/src/components/Examples/Charts2D/StylingAndTheming/StylingInCode/index.tsx
+++ b/Examples/src/components/Examples/Charts2D/StylingAndTheming/StylingInCode/index.tsx
@@ -1,11 +1,11 @@
 import * as React from "react";
 import { appTheme } from "../../../theme";
 import { SciChartReact } from "scichart-react";
-import classes from "../../../styles/Examples.module.scss";
+import commonClasses from "../../../styles/Examples.module.scss";
 import { drawExample } from "./drawExample";
 
 // React component needed as our examples app is react.
 // SciChart can be used in Angular, Vue, Blazor and vanilla JS! See our Github repo for more info
 export default function ChartComponent() {
-    return <SciChartReact initChart={drawExample} className={classes.ChartWrapper} />;
+    return <SciChartReact initChart={drawExample} className={commonClasses.ChartWrapper} />;
 }

--- a/Examples/src/components/Examples/Charts2D/StylingAndTheming/TransparentBackground/index.tsx
+++ b/Examples/src/components/Examples/Charts2D/StylingAndTheming/TransparentBackground/index.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import classes from "../../../styles/Examples.module.scss";
+import commonClasses from "../../../styles/Examples.module.scss";
 import BackgroundImage from "./BackgroundGradient.jpg";
 import { SciChartReact } from "scichart-react";
 import { drawExample } from "./drawExample";
@@ -7,7 +7,7 @@ import { drawExample } from "./drawExample";
 export default function TransparentBackground() {
     return (
         <div
-            className={classes.ChartWrapper}
+            className={commonClasses.ChartWrapper}
             style={{ backgroundImage: `url(${BackgroundImage})`, backgroundSize: "100% 100%" }}
         >
             <SciChartReact initChart={drawExample} />

--- a/Examples/src/components/Examples/Charts2D/StylingAndTheming/UsePointMarkers/index.tsx
+++ b/Examples/src/components/Examples/Charts2D/StylingAndTheming/UsePointMarkers/index.tsx
@@ -1,12 +1,12 @@
 import * as React from "react";
 import { appTheme } from "../../../theme";
 import { SciChartReact } from "scichart-react";
-import classes from "../../../styles/Examples.module.scss";
+import commonClasses from "../../../styles/Examples.module.scss";
 import { drawExample } from "./drawExample";
 import customPointImage from "./img/CustomMarkerImage.png";
 
 // React component needed as our examples app is react.
 // SciChart can be used in Angular, Vue, Blazor and vanilla JS! See our Github repo for more info
 export default function ChartComponent() {
-    return <SciChartReact initChart={drawExample(customPointImage)} className={classes.ChartWrapper} />;
+    return <SciChartReact initChart={drawExample(customPointImage)} className={commonClasses.ChartWrapper} />;
 }

--- a/Examples/src/components/Examples/Charts2D/StylingAndTheming/UsingThemeManager/index.tsx
+++ b/Examples/src/components/Examples/Charts2D/StylingAndTheming/UsingThemeManager/index.tsx
@@ -2,7 +2,7 @@ import { makeStyles } from "@mui/styles";
 import * as React from "react";
 import { SciChartReact } from "scichart-react";
 import { appTheme } from "../../../theme";
-import classes from "../../../styles/Examples.module.scss";
+import commonClasses from "../../../styles/Examples.module.scss";
 import { getChartsInitializationAPI } from "./drawExample";
 
 // Styles for the 2x2 grid
@@ -37,7 +37,7 @@ export default function ChartComponent() {
     const localClasses = useStyles();
 
     return (
-        <div className={classes.ChartWrapper}>
+        <div className={commonClasses.ChartWrapper}>
             <div className={localClasses.flexOuterContainer}>
                 <div className={localClasses.flexContainerRow}>
                     <SciChartReact

--- a/Examples/src/components/Examples/Charts2D/StylingAndTheming/UsingThemeManager/index.tsx
+++ b/Examples/src/components/Examples/Charts2D/StylingAndTheming/UsingThemeManager/index.tsx
@@ -1,4 +1,4 @@
-import { makeStyles } from "@mui/styles";
+import { makeStyles } from "tss-react/mui";
 import * as React from "react";
 import { SciChartReact } from "scichart-react";
 import { appTheme } from "../../../theme";
@@ -6,7 +6,7 @@ import commonClasses from "../../../styles/Examples.module.scss";
 import { getChartsInitializationAPI } from "./drawExample";
 
 // Styles for the 2x2 grid
-const useStyles = makeStyles((theme) => ({
+const useStyles = makeStyles()((theme) => ({
     flexOuterContainer: {
         width: "100%",
         height: "100%",
@@ -34,7 +34,7 @@ const useStyles = makeStyles((theme) => ({
 export default function ChartComponent() {
     const [chartsInitializationAPI] = React.useState(getChartsInitializationAPI());
 
-    const classes = useStyles();
+    const { classes } = useStyles();
 
     return (
         <div className={commonClasses.ChartWrapper}>

--- a/Examples/src/components/Examples/Charts2D/StylingAndTheming/UsingThemeManager/index.tsx
+++ b/Examples/src/components/Examples/Charts2D/StylingAndTheming/UsingThemeManager/index.tsx
@@ -34,28 +34,19 @@ const useStyles = makeStyles((theme) => ({
 export default function ChartComponent() {
     const [chartsInitializationAPI] = React.useState(getChartsInitializationAPI());
 
-    const localClasses = useStyles();
+    const classes = useStyles();
 
     return (
         <div className={commonClasses.ChartWrapper}>
-            <div className={localClasses.flexOuterContainer}>
-                <div className={localClasses.flexContainerRow}>
-                    <SciChartReact
-                        className={localClasses.item}
-                        initChart={chartsInitializationAPI.createNavyThemeChart}
-                    />
-                    <SciChartReact
-                        className={localClasses.item}
-                        initChart={chartsInitializationAPI.createLightThemeChart}
-                    />
+            <div className={classes.flexOuterContainer}>
+                <div className={classes.flexContainerRow}>
+                    <SciChartReact className={classes.item} initChart={chartsInitializationAPI.createNavyThemeChart} />
+                    <SciChartReact className={classes.item} initChart={chartsInitializationAPI.createLightThemeChart} />
                 </div>
-                <div className={localClasses.flexContainerRow}>
+                <div className={classes.flexContainerRow}>
+                    <SciChartReact className={classes.item} initChart={chartsInitializationAPI.createDarkThemeChart} />
                     <SciChartReact
-                        className={localClasses.item}
-                        initChart={chartsInitializationAPI.createDarkThemeChart}
-                    />
-                    <SciChartReact
-                        className={localClasses.item}
+                        className={classes.item}
                         initChart={chartsInitializationAPI.createCustomThemeChart}
                     />
                 </div>

--- a/Examples/src/components/Examples/Charts2D/TooltipsAndHittest/DatapointSelection/index.tsx
+++ b/Examples/src/components/Examples/Charts2D/TooltipsAndHittest/DatapointSelection/index.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import { CSSProperties } from "react";
-import classes from "../../../styles/Examples.module.scss";
+import commonClasses from "../../../styles/Examples.module.scss";
 import { appTheme } from "../../../theme";
 import { SciChartReact } from "scichart-react";
 import { DataPointInfo } from "scichart";
@@ -10,7 +10,7 @@ export default function DatapointSelection() {
     const [selectedPoints, setSelectedPoints] = React.useState<DataPointInfo[]>([]);
 
     return (
-        <div className={classes.FullHeightChartWrapper}>
+        <div className={commonClasses.FullHeightChartWrapper}>
             <div style={{ display: "flex", flexDirection: "row", height: "100%" }}>
                 <SciChartReact
                     style={chartStyle}

--- a/Examples/src/components/Examples/Charts2D/TooltipsAndHittest/HitTestAPI/index.tsx
+++ b/Examples/src/components/Examples/Charts2D/TooltipsAndHittest/HitTestAPI/index.tsx
@@ -2,11 +2,11 @@ import * as React from "react";
 import commonClasses from "../../../styles/Examples.module.scss";
 import { appTheme } from "../../../theme";
 import { ToggleButton, ToggleButtonGroup } from "@mui/material";
-import { makeStyles } from "@mui/styles";
+import { makeStyles } from "tss-react/mui";
 import { SciChartReact, TResolvedReturnType } from "scichart-react";
 import { HIT_TEST, HIT_TEST_DATAPOINT, HIT_TEST_X_SLICE, drawExample } from "./drawExample";
 
-const useStyles = makeStyles((theme) => ({
+const useStyles = makeStyles()((theme) => ({
     flexOuterContainer: {
         width: "100%",
         height: "100%",
@@ -40,7 +40,7 @@ export default function ChartComponent() {
         }
     };
 
-    const classes = useStyles();
+    const { classes } = useStyles();
     return (
         <div className={commonClasses.ChartWrapper}>
             <div className={classes.flexOuterContainer}>

--- a/Examples/src/components/Examples/Charts2D/TooltipsAndHittest/HitTestAPI/index.tsx
+++ b/Examples/src/components/Examples/Charts2D/TooltipsAndHittest/HitTestAPI/index.tsx
@@ -40,12 +40,12 @@ export default function ChartComponent() {
         }
     };
 
-    const localClasses = useStyles();
+    const classes = useStyles();
     return (
         <div className={commonClasses.ChartWrapper}>
-            <div className={localClasses.flexOuterContainer}>
+            <div className={classes.flexOuterContainer}>
                 <ToggleButtonGroup
-                    className={localClasses.toolbarRow}
+                    className={classes.toolbarRow}
                     exclusive
                     value={preset}
                     onChange={handlePreset}
@@ -64,7 +64,7 @@ export default function ChartComponent() {
                     </ToggleButton>
                 </ToggleButtonGroup>
                 <SciChartReact
-                    className={localClasses.chartArea}
+                    className={classes.chartArea}
                     initChart={drawExample}
                     onInit={(initResult: TResolvedReturnType<typeof drawExample>) => {
                         controlsRef.current = initResult.controls;

--- a/Examples/src/components/Examples/Charts2D/TooltipsAndHittest/HitTestAPI/index.tsx
+++ b/Examples/src/components/Examples/Charts2D/TooltipsAndHittest/HitTestAPI/index.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import classes from "../../../styles/Examples.module.scss";
+import commonClasses from "../../../styles/Examples.module.scss";
 import { appTheme } from "../../../theme";
 import { ToggleButton, ToggleButtonGroup } from "@mui/material";
 import { makeStyles } from "@mui/styles";
@@ -42,7 +42,7 @@ export default function ChartComponent() {
 
     const localClasses = useStyles();
     return (
-        <div className={classes.ChartWrapper}>
+        <div className={commonClasses.ChartWrapper}>
             <div className={localClasses.flexOuterContainer}>
                 <ToggleButtonGroup
                     className={localClasses.toolbarRow}

--- a/Examples/src/components/Examples/Charts2D/TooltipsAndHittest/MetaData/index.tsx
+++ b/Examples/src/components/Examples/Charts2D/TooltipsAndHittest/MetaData/index.tsx
@@ -1,11 +1,11 @@
 import * as React from "react";
 import { appTheme } from "../../../theme";
 import { SciChartReact } from "scichart-react";
-import classes from "../../../styles/Examples.module.scss";
+import commonClasses from "../../../styles/Examples.module.scss";
 import { drawExample } from "./drawExample";
 
 // React component needed as our examples app is react.
 // SciChart can be used in Angular, Vue, Blazor and vanilla JS! See our Github repo for more info
 export default function ChartComponent() {
-    return <SciChartReact initChart={drawExample} className={classes.ChartWrapper} />;
+    return <SciChartReact initChart={drawExample} className={commonClasses.ChartWrapper} />;
 }

--- a/Examples/src/components/Examples/Charts2D/TooltipsAndHittest/SeriesSelection/index.tsx
+++ b/Examples/src/components/Examples/Charts2D/TooltipsAndHittest/SeriesSelection/index.tsx
@@ -1,11 +1,11 @@
 import * as React from "react";
 import { appTheme } from "../../../theme";
 import { SciChartReact } from "scichart-react";
-import classes from "../../../styles/Examples.module.scss";
+import commonClasses from "../../../styles/Examples.module.scss";
 import { drawExample } from "./drawExample";
 
 // React component needed as our examples app is react.
 // SciChart can be used in Angular, Vue, Blazor and vanilla JS! See our Github repo for more info
 export default function ChartComponent() {
-    return <SciChartReact initChart={drawExample} className={classes.ChartWrapper} />;
+    return <SciChartReact initChart={drawExample} className={commonClasses.ChartWrapper} />;
 }

--- a/Examples/src/components/Examples/Charts2D/TooltipsAndHittest/UsingCursorModifierTooltips/index.tsx
+++ b/Examples/src/components/Examples/Charts2D/TooltipsAndHittest/UsingCursorModifierTooltips/index.tsx
@@ -1,11 +1,11 @@
 import * as React from "react";
 import { appTheme } from "../../../theme";
 import { SciChartReact } from "scichart-react";
-import classes from "../../../styles/Examples.module.scss";
+import commonClasses from "../../../styles/Examples.module.scss";
 import { drawExample } from "./drawExample";
 
 // React component needed as our examples app is react.
 // SciChart can be used in Angular, Vue, Blazor and vanilla JS! See our Github repo for more info
 export default function ChartComponent() {
-    return <SciChartReact initChart={drawExample} className={classes.ChartWrapper} />;
+    return <SciChartReact initChart={drawExample} className={commonClasses.ChartWrapper} />;
 }

--- a/Examples/src/components/Examples/Charts2D/TooltipsAndHittest/UsingRolloverModifierTooltips/index.tsx
+++ b/Examples/src/components/Examples/Charts2D/TooltipsAndHittest/UsingRolloverModifierTooltips/index.tsx
@@ -1,11 +1,11 @@
 import * as React from "react";
 import { appTheme } from "../../../theme";
 import { SciChartReact } from "scichart-react";
-import classes from "../../../styles/Examples.module.scss";
+import commonClasses from "../../../styles/Examples.module.scss";
 import { drawExample } from "./drawExample";
 
 // React component needed as our examples app is react.
 // SciChart can be used in Angular, Vue, Blazor and vanilla JS! See our Github repo for more info
 export default function ChartComponent() {
-    return <SciChartReact initChart={drawExample} className={classes.ChartWrapper} />;
+    return <SciChartReact initChart={drawExample} className={commonClasses.ChartWrapper} />;
 }

--- a/Examples/src/components/Examples/Charts2D/TooltipsAndHittest/UsingVerticalSliceModifier/index.tsx
+++ b/Examples/src/components/Examples/Charts2D/TooltipsAndHittest/UsingVerticalSliceModifier/index.tsx
@@ -1,11 +1,11 @@
 import * as React from "react";
 import { appTheme } from "../../../theme";
 import { SciChartReact } from "scichart-react";
-import classes from "../../../styles/Examples.module.scss";
+import commonClasses from "../../../styles/Examples.module.scss";
 import { drawExample } from "./drawExample";
 
 // React component needed as our examples app is react.
 // SciChart can be used in Angular, Vue, Blazor and vanilla JS! See our Github repo for more info
 export default function ChartComponent() {
-    return <SciChartReact initChart={drawExample} className={classes.ChartWrapper} />;
+    return <SciChartReact initChart={drawExample} className={commonClasses.ChartWrapper} />;
 }

--- a/Examples/src/components/Examples/Charts2D/ZoomingAndPanning/DragAxisToScale/index.tsx
+++ b/Examples/src/components/Examples/Charts2D/ZoomingAndPanning/DragAxisToScale/index.tsx
@@ -1,11 +1,11 @@
 import * as React from "react";
 import { appTheme } from "../../../theme";
 import { SciChartReact } from "scichart-react";
-import classes from "../../../styles/Examples.module.scss";
+import commonClasses from "../../../styles/Examples.module.scss";
 import { drawExample } from "./drawExample";
 
 // React component needed as our examples app is react.
 // SciChart can be used in Angular, Vue, Blazor and vanilla JS! See our Github repo for more info
 export default function ChartComponent() {
-    return <SciChartReact initChart={drawExample} className={classes.ChartWrapper} />;
+    return <SciChartReact initChart={drawExample} className={commonClasses.ChartWrapper} />;
 }

--- a/Examples/src/components/Examples/Charts2D/ZoomingAndPanning/MultipleZoomPanModifiers/index.tsx
+++ b/Examples/src/components/Examples/Charts2D/ZoomingAndPanning/MultipleZoomPanModifiers/index.tsx
@@ -1,11 +1,11 @@
 import * as React from "react";
 import { appTheme } from "../../../theme";
 import { SciChartReact } from "scichart-react";
-import classes from "../../../styles/Examples.module.scss";
+import commonClasses from "../../../styles/Examples.module.scss";
 import { drawExample } from "./drawExample";
 
 // React component needed as our examples app is react.
 // SciChart can be used in Angular, Vue, Blazor and vanilla JS! See our Github repo for more info
 export default function ChartComponent() {
-    return <SciChartReact initChart={drawExample} className={classes.ChartWrapper} />;
+    return <SciChartReact initChart={drawExample} className={commonClasses.ChartWrapper} />;
 }

--- a/Examples/src/components/Examples/Charts2D/ZoomingAndPanning/OverviewModifier/index.tsx
+++ b/Examples/src/components/Examples/Charts2D/ZoomingAndPanning/OverviewModifier/index.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import classes from "../../../styles/Examples.module.scss";
+import commonClasses from "../../../styles/Examples.module.scss";
 import { SciChartSurface } from "scichart";
 import { SciChartReact, SciChartNestedOverview, TResolvedReturnType } from "scichart-react";
 import { drawExample, overViewOption } from "./drawExample";
@@ -8,7 +8,7 @@ export default function Overview() {
     const sciChartSurfaceRef = React.useRef<SciChartSurface>();
 
     return (
-        <div className={classes.ChartWrapper}>
+        <div className={commonClasses.ChartWrapper}>
             <div style={{ display: "flex", flexDirection: "column", height: "100%" }}>
                 <SciChartReact
                     initChart={drawExample}

--- a/Examples/src/components/Examples/Charts2D/ZoomingAndPanning/RealtimeZoomPan/index.tsx
+++ b/Examples/src/components/Examples/Charts2D/ZoomingAndPanning/RealtimeZoomPan/index.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { appTheme } from "../../../theme";
 import { SciChartReact, TResolvedReturnType } from "scichart-react";
-import classes from "../../../styles/Examples.module.scss";
+import commonClasses from "../../../styles/Examples.module.scss";
 import { drawExample } from "./drawExample";
 
 // React component needed as our examples app is react.
@@ -10,7 +10,7 @@ export default function ChartComponent() {
     return (
         <SciChartReact
             initChart={drawExample}
-            className={classes.ChartWrapper}
+            className={commonClasses.ChartWrapper}
             onDelete={(initResult: TResolvedReturnType<typeof drawExample>) => {
                 initResult.controls.handleStop();
             }}

--- a/Examples/src/components/Examples/Charts2D/ZoomingAndPanning/VirtualizedDataWithOverview/index.tsx
+++ b/Examples/src/components/Examples/Charts2D/ZoomingAndPanning/VirtualizedDataWithOverview/index.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { useState } from "react";
 import { SciChartReact } from "scichart-react";
-import classes from "../../../styles/Examples.module.scss";
+import commonClasses from "../../../styles/Examples.module.scss";
 import { getChartsInitializationApi } from "./drawExample";
 
 export default function VirtualizedDataOverview() {
@@ -9,7 +9,7 @@ export default function VirtualizedDataOverview() {
     const [isMainChartInitialized, setIsMainChartInitialized] = useState(false);
 
     return (
-        <div className={classes.ChartWrapper}>
+        <div className={commonClasses.ChartWrapper}>
             <div style={{ display: "flex", flexDirection: "column", height: "100%" }}>
                 <SciChartReact
                     style={{ flexBasis: 600, flexGrow: 1, flexShrink: 1 }}

--- a/Examples/src/components/Examples/Charts3D/Basic3DChartTypes/Bubble3DChart/index.tsx
+++ b/Examples/src/components/Examples/Charts3D/Basic3DChartTypes/Bubble3DChart/index.tsx
@@ -1,11 +1,11 @@
 import * as React from "react";
 import { appTheme } from "../../../theme";
 import { SciChartReact } from "scichart-react";
-import classes from "../../../styles/Examples.module.scss";
+import commonClasses from "../../../styles/Examples.module.scss";
 import { drawExample } from "./drawExample";
 
 // React component needed as our examples app is react.
 // SciChart can be used in Angular, Vue, Blazor and vanilla JS! See our Github repo for more info
 export default function ChartComponent() {
-    return <SciChartReact initChart={drawExample} className={classes.ChartWrapper} />;
+    return <SciChartReact initChart={drawExample} className={commonClasses.ChartWrapper} />;
 }

--- a/Examples/src/components/Examples/Charts3D/Basic3DChartTypes/PointLine3DChart/index.tsx
+++ b/Examples/src/components/Examples/Charts3D/Basic3DChartTypes/PointLine3DChart/index.tsx
@@ -1,12 +1,12 @@
 import * as React from "react";
-import classes from "../../../styles/Examples.module.scss";
+import commonClasses from "../../../styles/Examples.module.scss";
 import { drawExample, drawHeatmapLegend } from "./drawExample";
 import { SciChartReact } from "scichart-react";
 
 // REACT COMPONENT
 export default function PointLine3DChart() {
     return (
-        <div className={classes.ChartWrapper}>
+        <div className={commonClasses.ChartWrapper}>
             <div style={{ position: "relative", height: "100%", width: "100%" }}>
                 <SciChartReact
                     style={{ position: "absolute", height: "100%", width: "100%" }}

--- a/Examples/src/components/Examples/Charts3D/Basic3DChartTypes/RealtimeSurfaceMesh3DChart/index.tsx
+++ b/Examples/src/components/Examples/Charts3D/Basic3DChartTypes/RealtimeSurfaceMesh3DChart/index.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import classes from "../../../styles/Examples.module.scss";
+import commonClasses from "../../../styles/Examples.module.scss";
 import { SciChartReact, TResolvedReturnType } from "scichart-react";
 import { drawExample } from "./drawExample";
 import { SciChart3DSurface } from "scichart";
@@ -7,7 +7,7 @@ import { SciChart3DSurface } from "scichart";
 // REACT COMPONENT
 export default function RealtimeSurfaceMesh3DChart() {
     return (
-        <div className={classes.ChartWrapper}>
+        <div className={commonClasses.ChartWrapper}>
             <div style={{ position: "relative", height: "100%", width: "100%" }}>
                 <SciChartReact<SciChart3DSurface, TResolvedReturnType<typeof drawExample>>
                     initChart={drawExample}

--- a/Examples/src/components/Examples/Charts3D/Basic3DChartTypes/SurfaceMesh3DChart/index.tsx
+++ b/Examples/src/components/Examples/Charts3D/Basic3DChartTypes/SurfaceMesh3DChart/index.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import classes from "../../../styles/Examples.module.scss";
+import commonClasses from "../../../styles/Examples.module.scss";
 
 import { SciChart3DSurface } from "scichart";
 import { drawExample, drawHeatmapLegend } from "./drawExample";
@@ -8,7 +8,7 @@ import { SciChartReact, TResolvedReturnType } from "scichart-react";
 // REACT COMPONENT
 export default function SurfaceMesh3DChart() {
     return (
-        <div className={classes.ChartWrapper}>
+        <div className={commonClasses.ChartWrapper}>
             <div style={{ position: "relative", height: "100%", width: "100%" }}>
                 <SciChartReact
                     initChart={drawExample}

--- a/Examples/src/components/Examples/ExampleRootDetails.tsx
+++ b/Examples/src/components/Examples/ExampleRootDetails.tsx
@@ -41,7 +41,7 @@ const ExamplesRootDetails: FC<TProps> = (props) => {
                 image={exampleImage}
                 url={exampleUrl}
             />
-            <div className={classes.Example}>
+            <div className={`${classes.Example} AnExampleContainer`}>
                 <ExampleComponent />
             </div>
         </div>

--- a/Examples/src/components/Examples/ExampleRootDetails.tsx
+++ b/Examples/src/components/Examples/ExampleRootDetails.tsx
@@ -4,7 +4,7 @@ import { TExamplePage } from "../AppRouter/examplePages";
 import { updateGoogleTagManagerPage } from "../../utils/googleTagManager";
 import { getExampleComponent } from "../AppRouter/examples";
 import { ExampleStrings } from "./ExampleStrings";
-import classes from "./styles/Examples.module.scss";
+import commonClasses from "./styles/Examples.module.scss";
 import ComponentWrapper from "../ComponentWrapper/ComponentWrapper";
 import { GalleryItem } from "../../helpers/types/types";
 import { FrameworkContext } from "../../helpers/shared/Helpers/FrameworkContext";
@@ -33,7 +33,7 @@ const ExamplesRootDetails: FC<TProps> = (props) => {
         window.Prism?.highlightAll();
     }, []);
     return (
-        <div className={classes.ExamplesRoot}>
+        <div className={commonClasses.ExamplesRoot}>
             <SeoTags
                 title={seoTitleText}
                 keywords={seoKeywords}
@@ -41,7 +41,7 @@ const ExamplesRootDetails: FC<TProps> = (props) => {
                 image={exampleImage}
                 url={exampleUrl}
             />
-            <div className={`${classes.Example} AnExampleContainer`}>
+            <div className={`${commonClasses.Example} AnExampleContainer`}>
                 <ExampleComponent />
             </div>
         </div>

--- a/Examples/src/components/Examples/ExamplesRoot.tsx
+++ b/Examples/src/components/Examples/ExamplesRoot.tsx
@@ -5,7 +5,7 @@ import { updateGoogleTagManagerPage } from "../../utils/googleTagManager";
 import { ALL_MENU_ITEMS, getExampleComponent } from "../AppRouter/examples";
 import { Button } from "@mui/material";
 import { ExampleStrings } from "./ExampleStrings";
-import classes from "./styles/Examples.module.scss";
+import commonClasses from "./styles/Examples.module.scss";
 import ComponentWrapper from "../ComponentWrapper/ComponentWrapper";
 import Gallery from "../Gallery/Gallery";
 import { GalleryItem } from "../../helpers/types/types";
@@ -82,7 +82,7 @@ const ExamplesRoot: FC<TProps> = (props) => {
         };
     }, []);
     return (
-        <div className={classes.ExamplesRoot}>
+        <div className={commonClasses.ExamplesRoot}>
             <SeoTags
                 title={seoTitleText}
                 keywords={seoKeywords}
@@ -90,16 +90,16 @@ const ExamplesRoot: FC<TProps> = (props) => {
                 image={exampleImage}
                 url={exampleUrl}
             />
-            <div className={classes.Body}>
-                <div className={classes.ColMain}>
+            <div className={commonClasses.Body}>
+                <div className={commonClasses.ColMain}>
                     <ComponentWrapper>
-                        <div className={classes.ExampleRootDescription}>
+                        <div className={commonClasses.ExampleRootDescription}>
                             <h5>SciChart.js Demo</h5>
 
-                            <p className={classes.ExampleDescriptionText}>
+                            <p className={commonClasses.ExampleDescriptionText}>
                                 {" "}
                                 <a
-                                    className={classes.ExampleRootDescriptionLink}
+                                    className={commonClasses.ExampleRootDescriptionLink}
                                     target="_blank"
                                     href={`https://scichart.com/example/javascript-chart/javascript-${exampleUrl}/`}
                                     title={titleText}
@@ -108,7 +108,7 @@ const ExamplesRoot: FC<TProps> = (props) => {
                                 </a>{" "}
                                 is part of the SciChart.js demo app. To clone the repo for this demo, visit{" "}
                                 <a
-                                    className={classes.ExampleRootDescriptionLink}
+                                    className={commonClasses.ExampleRootDescriptionLink}
                                     target="_blank"
                                     rel="external"
                                     href="https://github.com/abtsoftware/scichart.js.examples"
@@ -118,7 +118,7 @@ const ExamplesRoot: FC<TProps> = (props) => {
                                 </a>
                                 . For getting-started &amp; docs, see above!{" "}
                                 <a
-                                    className={classes.ExampleRootDescriptionLink}
+                                    className={commonClasses.ExampleRootDescriptionLink}
                                     target="_blank"
                                     rel="nofollow external"
                                     href={`/codesandbox/${exampleUrl}?codesandbox=1&framework=${framework}`}
@@ -130,11 +130,11 @@ const ExamplesRoot: FC<TProps> = (props) => {
                     </ComponentWrapper>
 
                     <ComponentWrapper>
-                        <h1 className={classes.Title}>{titleText} </h1>
+                        <h1 className={commonClasses.Title}>{titleText} </h1>
 
-                        <div className={classes.ExampleWrapper}>
-                            <div className={classes.ExampleDescription}>
-                                <div className={classes.Subtitle}>{subtitleText}</div>
+                        <div className={commonClasses.ExampleWrapper}>
+                            <div className={commonClasses.ExampleDescription}>
+                                <div className={commonClasses.Subtitle}>{subtitleText}</div>
                                 <ExampleDescription
                                     documentationLinks={documentationLinks}
                                     tips={tips}
@@ -142,9 +142,9 @@ const ExamplesRoot: FC<TProps> = (props) => {
                                     previewDescription={previewDescription}
                                 />
                             </div>
-                            <div className={classes.Example}>
+                            <div className={commonClasses.Example}>
                                 <ExampleComponent />
-                                <div className={classes.ButtonsWrapper}>
+                                <div className={commonClasses.ButtonsWrapper}>
                                     {/*<Button*/}
                                     {/*    onClick={() => {*/}
                                     {/*        setShowSource(!showSource);*/}
@@ -155,27 +155,27 @@ const ExamplesRoot: FC<TProps> = (props) => {
                                     {/*    }}*/}
                                     {/*>*/}
                                     {/*    <CodeIcon />*/}
-                                    {/*    <span className={classes.ButtonsText}>VIEW SOURCE CODE</span>*/}
+                                    {/*    <span className={commonClasses.ButtonsText}>VIEW SOURCE CODE</span>*/}
                                     {/*</Button>*/}
-                                    <Button className={classes.GitHubLink}>
+                                    <Button className={commonClasses.GitHubLink}>
                                         <GitHubIcon />
                                         <a
                                             href={fullGithubUrl}
                                             title={fullGithubUrl}
                                             target="_blank"
-                                            className={classes.ButtonsText}
+                                            className={commonClasses.ButtonsText}
                                         >
                                             VIEW SOURCE IN GITHUB
                                         </a>
                                     </Button>
-                                    <Button className={classes.GitHubLink}>
+                                    <Button className={commonClasses.GitHubLink}>
                                         <SubdirectoryArrowRight />
                                         <a
                                             href={`/iframe/${examplePage.path}`}
                                             title="View this example in Full Screen"
                                             target="_blank"
                                             rel="nofollow"
-                                            className={classes.ButtonsText}
+                                            className={commonClasses.ButtonsText}
                                         >
                                             VIEW Full Screen
                                         </a>
@@ -186,7 +186,7 @@ const ExamplesRoot: FC<TProps> = (props) => {
                     </ComponentWrapper>
 
                     {seeAlso && (
-                        <div className={!showSource && !firstRender ? classes.Animation : ""}>
+                        <div className={!showSource && !firstRender ? commonClasses.Animation : ""}>
                             <Gallery examples={seeAlso} />
                         </div>
                     )}

--- a/Examples/src/components/Examples/FeaturedApps/FeatureDemos/AxisLayout/index.tsx
+++ b/Examples/src/components/Examples/FeaturedApps/FeatureDemos/AxisLayout/index.tsx
@@ -1,11 +1,11 @@
 import * as React from "react";
 import { appTheme } from "../../../theme";
 import { SciChartReact } from "scichart-react";
-import classes from "../../../styles/Examples.module.scss";
+import commonClasses from "../../../styles/Examples.module.scss";
 import { drawExample } from "./drawExample";
 
 // React component needed as our examples app is react.
 // SciChart can be used in Angular, Vue, Blazor and vanilla JS! See our Github repo for more info
 export default function ChartComponent() {
-    return <SciChartReact initChart={drawExample} className={classes.ChartWrapper} />;
+    return <SciChartReact initChart={drawExample} className={commonClasses.ChartWrapper} />;
 }

--- a/Examples/src/components/Examples/FeaturedApps/FeatureDemos/AxisTypes/index.tsx
+++ b/Examples/src/components/Examples/FeaturedApps/FeatureDemos/AxisTypes/index.tsx
@@ -52,12 +52,12 @@ export default function FeatureAxisTypes() {
         }
     };
 
-    const localClasses = useStyles();
+    const classes = useStyles();
 
     return (
         <div className={commonClasses.ChartWrapper}>
-            <div className={localClasses.flexOuterContainer}>
-                <div className={localClasses.toolbarRow}>
+            <div className={classes.flexOuterContainer}>
+                <div className={classes.toolbarRow}>
                     <ToggleButtonGroup
                         exclusive
                         value={preset}
@@ -78,7 +78,7 @@ export default function FeatureAxisTypes() {
                     </ToggleButtonGroup>
                 </div>
                 <SciChartReact
-                    className={localClasses.chartArea}
+                    className={classes.chartArea}
                     initChart={drawExample}
                     onInit={({ controls }: TResolvedReturnType<typeof drawExample>) => {
                         setControls(controls);

--- a/Examples/src/components/Examples/FeaturedApps/FeatureDemos/AxisTypes/index.tsx
+++ b/Examples/src/components/Examples/FeaturedApps/FeatureDemos/AxisTypes/index.tsx
@@ -1,7 +1,7 @@
 import { ToggleButton, ToggleButtonGroup } from "@mui/material";
 import * as React from "react";
 import { appTheme } from "../../../theme";
-import classes from "../../../styles/Examples.module.scss";
+import commonClasses from "../../../styles/Examples.module.scss";
 import { makeStyles } from "@mui/styles";
 import { SciChartReact, TResolvedReturnType } from "scichart-react";
 import { drawExample } from "./drawExample";
@@ -55,7 +55,7 @@ export default function FeatureAxisTypes() {
     const localClasses = useStyles();
 
     return (
-        <div className={classes.ChartWrapper}>
+        <div className={commonClasses.ChartWrapper}>
             <div className={localClasses.flexOuterContainer}>
                 <div className={localClasses.toolbarRow}>
                     <ToggleButtonGroup

--- a/Examples/src/components/Examples/FeaturedApps/FeatureDemos/AxisTypes/index.tsx
+++ b/Examples/src/components/Examples/FeaturedApps/FeatureDemos/AxisTypes/index.tsx
@@ -2,12 +2,12 @@ import { ToggleButton, ToggleButtonGroup } from "@mui/material";
 import * as React from "react";
 import { appTheme } from "../../../theme";
 import commonClasses from "../../../styles/Examples.module.scss";
-import { makeStyles } from "@mui/styles";
+import { makeStyles } from "tss-react/mui";
 import { SciChartReact, TResolvedReturnType } from "scichart-react";
 import { drawExample } from "./drawExample";
 import { useState } from "react";
 
-const useStyles = makeStyles((theme) => ({
+const useStyles = makeStyles()((theme) => ({
     flexOuterContainer: {
         width: "100%",
         height: "100%",
@@ -52,7 +52,7 @@ export default function FeatureAxisTypes() {
         }
     };
 
-    const classes = useStyles();
+    const { classes } = useStyles();
 
     return (
         <div className={commonClasses.ChartWrapper}>

--- a/Examples/src/components/Examples/FeaturedApps/FeatureDemos/ChartTitle/index.tsx
+++ b/Examples/src/components/Examples/FeaturedApps/FeatureDemos/ChartTitle/index.tsx
@@ -166,16 +166,16 @@ export default function FeatureChartTitle() {
             flex: "auto",
         },
     }));
-    const localClasses = useStyles();
+    const classes = useStyles();
 
     return (
         <div className={commonClasses.FullHeightChartWrapper} style={{ background: appTheme.DarkIndigo }}>
-            <div className={localClasses.flexContainer}>
-                <div className={localClasses.toolbar}>
+            <div className={classes.flexContainer}>
+                <div className={classes.toolbar}>
                     <FormControlLabel
                         control={
                             <textarea
-                                className={localClasses.textarea}
+                                className={classes.textarea}
                                 value={titleText}
                                 onChange={handleChangeTitleText}
                             ></textarea>
@@ -187,7 +187,7 @@ export default function FeatureChartTitle() {
                     <FormControlLabel
                         control={
                             <select
-                                className={localClasses.combobox}
+                                className={classes.combobox}
                                 value={titleAlignment}
                                 onChange={selectTitleTextAlignment}
                             >
@@ -205,7 +205,7 @@ export default function FeatureChartTitle() {
                     <FormControlLabel
                         control={
                             <select
-                                className={localClasses.combobox}
+                                className={classes.combobox}
                                 value={titlePosition}
                                 onChange={selectTitleTextPosition}
                             >
@@ -223,7 +223,7 @@ export default function FeatureChartTitle() {
                     <FormControlLabel
                         control={
                             <select
-                                className={localClasses.combobox}
+                                className={classes.combobox}
                                 value={multilineAlignment}
                                 onChange={selectTitleTextMultilineAlignment}
                             >

--- a/Examples/src/components/Examples/FeaturedApps/FeatureDemos/ChartTitle/index.tsx
+++ b/Examples/src/components/Examples/FeaturedApps/FeatureDemos/ChartTitle/index.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { FormControlLabel, Checkbox } from "@mui/material";
 import { makeStyles } from "@mui/styles";
-import classes from "../../../styles/Examples.module.scss";
+import commonClasses from "../../../styles/Examples.module.scss";
 import { appTheme } from "../../../theme";
 import { RandomWalkGenerator } from "../../../ExampleData/RandomWalkGenerator";
 import {
@@ -169,7 +169,7 @@ export default function FeatureChartTitle() {
     const localClasses = useStyles();
 
     return (
-        <div className={classes.FullHeightChartWrapper} style={{ background: appTheme.DarkIndigo }}>
+        <div className={commonClasses.FullHeightChartWrapper} style={{ background: appTheme.DarkIndigo }}>
             <div className={localClasses.flexContainer}>
                 <div className={localClasses.toolbar}>
                     <FormControlLabel

--- a/Examples/src/components/Examples/FeaturedApps/FeatureDemos/ChartTitle/index.tsx
+++ b/Examples/src/components/Examples/FeaturedApps/FeatureDemos/ChartTitle/index.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import { FormControlLabel, Checkbox } from "@mui/material";
-import { makeStyles } from "@mui/styles";
+import { makeStyles } from "tss-react/mui";
 import commonClasses from "../../../styles/Examples.module.scss";
 import { appTheme } from "../../../theme";
 import { RandomWalkGenerator } from "../../../ExampleData/RandomWalkGenerator";
@@ -136,7 +136,7 @@ export default function FeatureChartTitle() {
         }
     };
 
-    const useStyles = makeStyles((theme) => ({
+    const useStyles = makeStyles()((theme) => ({
         flexContainer: {
             display: "flex",
             flexDirection: "column",
@@ -166,7 +166,7 @@ export default function FeatureChartTitle() {
             flex: "auto",
         },
     }));
-    const classes = useStyles();
+    const { classes } = useStyles();
 
     return (
         <div className={commonClasses.FullHeightChartWrapper} style={{ background: appTheme.DarkIndigo }}>

--- a/Examples/src/components/Examples/FeaturedApps/FeatureDemos/SubChartsAPI/index.tsx
+++ b/Examples/src/components/Examples/FeaturedApps/FeatureDemos/SubChartsAPI/index.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import { appTheme } from "../../../theme";
-import classes from "../../../styles/Examples.module.scss";
+import commonClasses from "../../../styles/Examples.module.scss";
 import { makeStyles } from "@mui/styles";
 import { FormControl, ButtonGroup, Button, FormControlLabel, Checkbox } from "@mui/material";
 import {
@@ -417,10 +417,10 @@ export default function SubchartsGrid() {
         });
 
     return (
-        <div className={classes.ChartWrapper}>
+        <div className={commonClasses.ChartWrapper}>
             <div className={localClasses.flexOuterContainer}>
                 <div className={localClasses.toolbarRow}>
-                    <FormControl className={classes.formControl}>
+                    <FormControl className={commonClasses.formControl}>
                         <ButtonGroup size="medium" color="primary" aria-label="small outlined button group">
                             <Button id="startStreaming" onClick={handleStartStreaming}>
                                 {isDirty ? "ReStart" : "Start"}
@@ -430,7 +430,7 @@ export default function SubchartsGrid() {
                             </Button>
                         </ButtonGroup>
                     </FormControl>
-                    <FormControl className={classes.formControl}>
+                    <FormControl className={commonClasses.formControl}>
                         <FormControlLabel
                             control={<Checkbox onChange={handleLabelsChange} />}
                             label="Axis Labels"

--- a/Examples/src/components/Examples/FeaturedApps/FeatureDemos/SubChartsAPI/index.tsx
+++ b/Examples/src/components/Examples/FeaturedApps/FeatureDemos/SubChartsAPI/index.tsx
@@ -400,7 +400,7 @@ export default function SubchartsGrid() {
 
     const [messages, setMessages] = React.useState<TMessage[]>([]);
 
-    const localClasses = useStyles();
+    const classes = useStyles();
 
     const handleStartStreaming = () => {
         setIsDirty(false);
@@ -418,8 +418,8 @@ export default function SubchartsGrid() {
 
     return (
         <div className={commonClasses.ChartWrapper}>
-            <div className={localClasses.flexOuterContainer}>
-                <div className={localClasses.toolbarRow}>
+            <div className={classes.flexOuterContainer}>
+                <div className={classes.toolbarRow}>
                     <FormControl className={commonClasses.formControl}>
                         <ButtonGroup size="medium" color="primary" aria-label="small outlined button group">
                             <Button id="startStreaming" onClick={handleStartStreaming}>
@@ -437,16 +437,16 @@ export default function SubchartsGrid() {
                             labelPlacement="start"
                         />
                     </FormControl>
-                    <div className={localClasses.infoBlock}>
+                    <div className={classes.infoBlock}>
                         {messages.map((msg, index) => (
-                            <div key={index} className={localClasses.infoItem}>
+                            <div key={index} className={classes.infoItem}>
                                 {msg.title}: {msg.detail}
                             </div>
                         ))}
                     </div>
                 </div>
                 <SciChartReact
-                    className={localClasses.chartArea}
+                    className={classes.chartArea}
                     initChart={drawExample}
                     onInit={({ controls }: TResolvedReturnType<typeof drawExample>) => {
                         controlsRef.current = controls;

--- a/Examples/src/components/Examples/FeaturedApps/FeatureDemos/SubChartsAPI/index.tsx
+++ b/Examples/src/components/Examples/FeaturedApps/FeatureDemos/SubChartsAPI/index.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { appTheme } from "../../../theme";
 import commonClasses from "../../../styles/Examples.module.scss";
-import { makeStyles } from "@mui/styles";
+import { makeStyles } from "tss-react/mui";
 import { FormControl, ButtonGroup, Button, FormControlLabel, Checkbox } from "@mui/material";
 import {
     appendData,
@@ -358,7 +358,7 @@ export const drawGridExample = async (
     };
 };
 
-const useStyles = makeStyles((theme) => ({
+const useStyles = makeStyles()((theme) => ({
     flexOuterContainer: {
         width: "100%",
         height: "100%",
@@ -400,7 +400,7 @@ export default function SubchartsGrid() {
 
     const [messages, setMessages] = React.useState<TMessage[]>([]);
 
-    const classes = useStyles();
+    const { classes } = useStyles();
 
     const handleStartStreaming = () => {
         setIsDirty(false);

--- a/Examples/src/components/Examples/FeaturedApps/MedicalCharts/VitalSignsMonitorDemo/index.tsx
+++ b/Examples/src/components/Examples/FeaturedApps/MedicalCharts/VitalSignsMonitorDemo/index.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import classes from "../../../styles/Examples.module.scss";
+import commonClasses from "../../../styles/Examples.module.scss";
 import { appTheme } from "../../../theme";
 import { SciChartReact, TResolvedReturnType } from "scichart-react";
 import { drawExample } from "./drawExample";
@@ -15,10 +15,10 @@ export default function VitalSignsMonitorDemo() {
     const [infoBloodOxygenation, setInfoBloodOxygenation] = React.useState<number>(0);
 
     return (
-        <div className={classes.ChartWrapper}>
+        <div className={commonClasses.ChartWrapper}>
             <div style={{ display: "flex", height: "100%" }}>
                 <SciChartReact
-                    className={classes.VitalSigns}
+                    className={commonClasses.VitalSigns}
                     initChart={drawExample}
                     onInit={(initResult: TResolvedReturnType<typeof drawExample>) => {
                         initResult.subscribeToDataUpdates((info) => {
@@ -37,41 +37,41 @@ export default function VitalSignsMonitorDemo() {
                         };
                     }}
                 />
-                <div className={classes.InfoBoxContainer}>
+                <div className={commonClasses.InfoBoxContainer}>
                     <div
-                        className={classes.InfoBox}
+                        className={commonClasses.InfoBox}
                         style={{ color: appTheme.VividOrange, background: appTheme.Background }}
                     >
-                        <div className={classes.IbRow1}>
-                            <div className={classes.IbRow1Col1}>ECG</div>
+                        <div className={commonClasses.IbRow1}>
+                            <div className={commonClasses.IbRow1Col1}>ECG</div>
                         </div>
-                        <div className={classes.IbRow2}>
-                            <div className={classes.IbRow2Col1}>
+                        <div className={commonClasses.IbRow2}>
+                            <div className={commonClasses.IbRow2Col1}>
                                 <div>
                                     V1 - 1.4MM
                                     <br />
                                     ST | +0.6 || +0.9
                                 </div>
                             </div>
-                            <div className={classes.IbRow2Col2}>
+                            <div className={commonClasses.IbRow2Col2}>
                                 <div>{infoEcg}</div>
                             </div>
                         </div>
                     </div>
                     <div
-                        className={classes.InfoBox}
+                        className={commonClasses.InfoBox}
                         style={{ color: appTheme.VividSkyBlue, background: appTheme.Background }}
                     >
-                        <div className={classes.IbRow1}>
-                            <div className={classes.IbRow1Col1}>NIBP</div>
-                            <div className={classes.IbRow1Col2}>
+                        <div className={commonClasses.IbRow1}>
+                            <div className={commonClasses.IbRow1Col1}>NIBP</div>
+                            <div className={commonClasses.IbRow1Col2}>
                                 AUTO
                                 <br />
                                 145/95
                             </div>
                         </div>
-                        <div className={classes.IbRow2}>
-                            <div className={classes.IbRow2Col2}>
+                        <div className={commonClasses.IbRow2}>
+                            <div className={commonClasses.IbRow2Col2}>
                                 <div>
                                     {infoBloodPressure1}/{infoBloodPressure2}
                                 </div>
@@ -79,42 +79,42 @@ export default function VitalSignsMonitorDemo() {
                         </div>
                     </div>
                     <div
-                        className={classes.InfoBox}
+                        className={commonClasses.InfoBox}
                         style={{ color: appTheme.VividPink, background: appTheme.Background }}
                     >
-                        <div className={classes.IbRow1}>
-                            <div className={classes.IbRow1Col1}>SV</div>
-                            <div className={classes.IbRow1Col2}>
+                        <div className={commonClasses.IbRow1}>
+                            <div className={commonClasses.IbRow1Col1}>SV</div>
+                            <div className={commonClasses.IbRow1Col2}>
                                 ML 100
                                 <br />
                                 %**** 55
                             </div>
                         </div>
-                        <div className={classes.IbRow2}>
-                            <div className={classes.IbRow2Col2}>
+                        <div className={commonClasses.IbRow2}>
+                            <div className={commonClasses.IbRow2Col2}>
                                 <div>{infoBloodVolume.toFixed(1)}</div>
                             </div>
                         </div>
                     </div>
                     <div
-                        className={classes.InfoBox}
+                        className={commonClasses.InfoBox}
                         style={{ color: appTheme.VividTeal, background: appTheme.Background }}
                     >
-                        <div className={classes.IbRow1}>
-                            <div className={classes.IbRow1Col1}>
+                        <div className={commonClasses.IbRow1}>
+                            <div className={commonClasses.IbRow1Col1}>
                                 SPO<span style={{ fontSize: 12 }}>2</span>
                             </div>
-                            <div className={classes.IbRow1Col2}>18:06</div>
+                            <div className={commonClasses.IbRow1Col2}>18:06</div>
                         </div>
-                        <div className={classes.IbRow2}>
-                            <div className={classes.IbRow2Col1}>
+                        <div className={commonClasses.IbRow2}>
+                            <div className={commonClasses.IbRow2Col1}>
                                 <div>
                                     71-
                                     <br />
                                     RESP
                                 </div>
                             </div>
-                            <div className={classes.IbRow2Col2}>{infoBloodOxygenation}</div>
+                            <div className={commonClasses.IbRow2Col2}>{infoBloodOxygenation}</div>
                         </div>
                     </div>
                 </div>

--- a/Examples/src/components/Examples/FeaturedApps/PerformanceDemos/Load1MillionPoints/index.tsx
+++ b/Examples/src/components/Examples/FeaturedApps/PerformanceDemos/Load1MillionPoints/index.tsx
@@ -4,7 +4,7 @@ import AlertTitle from "@mui/material/AlertTitle";
 import * as React from "react";
 import { makeStyles } from "@mui/styles";
 import { appTheme } from "../../../theme";
-import classes from "../../../styles/Examples.module.scss";
+import commonClasses from "../../../styles/Examples.module.scss";
 import { SciChartReact, TResolvedReturnType } from "scichart-react";
 import { drawExample, TTimeSpan } from "./drawExample";
 
@@ -40,7 +40,7 @@ export default function Load1MillionPointsChart() {
     const localClasses = useStyles();
 
     return (
-        <div className={classes.ChartWrapper}>
+        <div className={commonClasses.ChartWrapper}>
             <div className={localClasses.flexOuterContainer}>
                 <SciChartReact
                     className={localClasses.chartArea}
@@ -68,7 +68,7 @@ export default function Load1MillionPointsChart() {
                         {timeSpans.length > 0 && (
                             <Alert
                                 key="0"
-                                className={classes.Notification}
+                                className={commonClasses.Notification}
                                 style={{ backgroundColor: appTheme.Indigo, color: appTheme.ForegroundColor }}
                             >
                                 <AlertTitle>Performance Results</AlertTitle>

--- a/Examples/src/components/Examples/FeaturedApps/PerformanceDemos/Load1MillionPoints/index.tsx
+++ b/Examples/src/components/Examples/FeaturedApps/PerformanceDemos/Load1MillionPoints/index.tsx
@@ -37,13 +37,13 @@ export default function Load1MillionPointsChart() {
         setTimeSpans([...newTimeSpans]);
     };
 
-    const localClasses = useStyles();
+    const classes = useStyles();
 
     return (
         <div className={commonClasses.ChartWrapper}>
-            <div className={localClasses.flexOuterContainer}>
+            <div className={classes.flexOuterContainer}>
                 <SciChartReact
-                    className={localClasses.chartArea}
+                    className={classes.chartArea}
                     initChart={drawExample}
                     onInit={({ controls }: TResolvedReturnType<typeof drawExample>) => {
                         setControls(controls);
@@ -54,7 +54,7 @@ export default function Load1MillionPointsChart() {
                         };
                     }}
                 />
-                <div className={localClasses.toolbarRow} style={{ minHeight: "140px" }}>
+                <div className={classes.toolbarRow} style={{ minHeight: "140px" }}>
                     <Button
                         id="loadPoints"
                         onClick={() => {

--- a/Examples/src/components/Examples/FeaturedApps/PerformanceDemos/Load1MillionPoints/index.tsx
+++ b/Examples/src/components/Examples/FeaturedApps/PerformanceDemos/Load1MillionPoints/index.tsx
@@ -2,13 +2,13 @@ import Button from "@mui/material/Button";
 import Alert from "@mui/material/Alert";
 import AlertTitle from "@mui/material/AlertTitle";
 import * as React from "react";
-import { makeStyles } from "@mui/styles";
+import { makeStyles } from "tss-react/mui";
 import { appTheme } from "../../../theme";
 import commonClasses from "../../../styles/Examples.module.scss";
 import { SciChartReact, TResolvedReturnType } from "scichart-react";
 import { drawExample, TTimeSpan } from "./drawExample";
 
-const useStyles = makeStyles((theme) => ({
+const useStyles = makeStyles()((theme) => ({
     flexOuterContainer: {
         width: "100%",
         height: "100%",
@@ -37,7 +37,7 @@ export default function Load1MillionPointsChart() {
         setTimeSpans([...newTimeSpans]);
     };
 
-    const classes = useStyles();
+    const { classes } = useStyles();
 
     return (
         <div className={commonClasses.ChartWrapper}>

--- a/Examples/src/components/Examples/FeaturedApps/PerformanceDemos/Load500By500/index.tsx
+++ b/Examples/src/components/Examples/FeaturedApps/PerformanceDemos/Load500By500/index.tsx
@@ -35,13 +35,13 @@ export default function Load500By500() {
     const controlsRef = useRef<TResolvedReturnType<typeof drawExample>["controls"]>(null);
     const [timeSpans, setTimeSpans] = React.useState<TTimeSpan[]>([]);
 
-    const localClasses = useStyles();
+    const classes = useStyles();
 
     return (
         <div className={commonClasses.ChartWrapper}>
-            <div className={localClasses.flexOuterContainer}>
+            <div className={classes.flexOuterContainer}>
                 <SciChartReact
-                    className={localClasses.chartArea}
+                    className={classes.chartArea}
                     initChart={(rootElement: string | HTMLDivElement) =>
                         drawExample(rootElement, (newTimeSpans: TTimeSpan[]) => {
                             setTimeSpans([...newTimeSpans]);
@@ -55,7 +55,7 @@ export default function Load500By500() {
                         controls.stopUpdate();
                     }}
                 />
-                <div className={localClasses.toolbarRow} style={{ minHeight: "140px" }}>
+                <div className={classes.toolbarRow} style={{ minHeight: "140px" }}>
                     <Button
                         onClick={() => {
                             controlsRef.current?.startUpdate();

--- a/Examples/src/components/Examples/FeaturedApps/PerformanceDemos/Load500By500/index.tsx
+++ b/Examples/src/components/Examples/FeaturedApps/PerformanceDemos/Load500By500/index.tsx
@@ -4,7 +4,7 @@ import AlertTitle from "@mui/material/AlertTitle";
 import Button from "@mui/material/Button";
 import Alert from "@mui/material/Alert";
 import { appTheme } from "../../../theme";
-import classes from "../../../styles/Examples.module.scss";
+import commonClasses from "../../../styles/Examples.module.scss";
 import { makeStyles } from "@mui/styles";
 
 import { SciChartReact, TResolvedReturnType } from "scichart-react";
@@ -38,7 +38,7 @@ export default function Load500By500() {
     const localClasses = useStyles();
 
     return (
-        <div className={classes.ChartWrapper}>
+        <div className={commonClasses.ChartWrapper}>
             <div className={localClasses.flexOuterContainer}>
                 <SciChartReact
                     className={localClasses.chartArea}
@@ -68,7 +68,7 @@ export default function Load500By500() {
                         {timeSpans.length > 0 && (
                             <Alert
                                 key="0"
-                                className={classes.Notification}
+                                className={commonClasses.Notification}
                                 style={{ backgroundColor: appTheme.Indigo, color: appTheme.ForegroundColor }}
                             >
                                 <AlertTitle>Performance Results</AlertTitle>

--- a/Examples/src/components/Examples/FeaturedApps/PerformanceDemos/Load500By500/index.tsx
+++ b/Examples/src/components/Examples/FeaturedApps/PerformanceDemos/Load500By500/index.tsx
@@ -5,12 +5,12 @@ import Button from "@mui/material/Button";
 import Alert from "@mui/material/Alert";
 import { appTheme } from "../../../theme";
 import commonClasses from "../../../styles/Examples.module.scss";
-import { makeStyles } from "@mui/styles";
+import { makeStyles } from "tss-react/mui";
 
 import { SciChartReact, TResolvedReturnType } from "scichart-react";
 import { drawExample, TTimeSpan } from "./drawExample";
 
-const useStyles = makeStyles((theme) => ({
+const useStyles = makeStyles()((theme) => ({
     flexOuterContainer: {
         width: "100%",
         height: "100%",
@@ -35,7 +35,7 @@ export default function Load500By500() {
     const controlsRef = useRef<TResolvedReturnType<typeof drawExample>["controls"]>(null);
     const [timeSpans, setTimeSpans] = React.useState<TTimeSpan[]>([]);
 
-    const classes = useStyles();
+    const { classes } = useStyles();
 
     return (
         <div className={commonClasses.ChartWrapper}>

--- a/Examples/src/components/Examples/FeaturedApps/PerformanceDemos/RealtimeGhostedTraces/index.tsx
+++ b/Examples/src/components/Examples/FeaturedApps/PerformanceDemos/RealtimeGhostedTraces/index.tsx
@@ -3,7 +3,7 @@ import { appTheme } from "../../../theme";
 import { ExampleDataProvider } from "../../../ExampleData/ExampleDataProvider";
 import commonClasses from "../../../styles/Examples.module.scss";
 import Button from "@mui/material/Button";
-import { makeStyles } from "@mui/styles";
+import { makeStyles } from "tss-react/mui";
 
 import {
     CentralAxesLayoutManager,
@@ -138,7 +138,7 @@ const drawExample = async (rootElement: string | HTMLDivElement) => {
     return { wasmContext, sciChartSurface, controls: { startAnimation, stopAnimation } };
 };
 
-const useStyles = makeStyles((theme) => ({
+const useStyles = makeStyles()((theme) => ({
     flexOuterContainer: {
         width: "100%",
         height: "100%",
@@ -167,7 +167,7 @@ export default function RealtimeGhostedTraces() {
 
     const [stats, setStats] = React.useState({ numberSeries: 0, numberPoints: 0, fps: 0 });
 
-    const classes = useStyles();
+    const { classes } = useStyles();
 
     return (
         <React.Fragment>

--- a/Examples/src/components/Examples/FeaturedApps/PerformanceDemos/RealtimeGhostedTraces/index.tsx
+++ b/Examples/src/components/Examples/FeaturedApps/PerformanceDemos/RealtimeGhostedTraces/index.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { appTheme } from "../../../theme";
 import { ExampleDataProvider } from "../../../ExampleData/ExampleDataProvider";
-import classes from "../../../styles/Examples.module.scss";
+import commonClasses from "../../../styles/Examples.module.scss";
 import Button from "@mui/material/Button";
 import { makeStyles } from "@mui/styles";
 
@@ -171,7 +171,7 @@ export default function RealtimeGhostedTraces() {
 
     return (
         <React.Fragment>
-            <div className={classes.ChartWrapper}>
+            <div className={commonClasses.ChartWrapper}>
                 <div className={localClasses.flexOuterContainer}>
                     <div className={localClasses.toolbarRow}>
                         <Button

--- a/Examples/src/components/Examples/FeaturedApps/PerformanceDemos/RealtimeGhostedTraces/index.tsx
+++ b/Examples/src/components/Examples/FeaturedApps/PerformanceDemos/RealtimeGhostedTraces/index.tsx
@@ -167,13 +167,13 @@ export default function RealtimeGhostedTraces() {
 
     const [stats, setStats] = React.useState({ numberSeries: 0, numberPoints: 0, fps: 0 });
 
-    const localClasses = useStyles();
+    const classes = useStyles();
 
     return (
         <React.Fragment>
             <div className={commonClasses.ChartWrapper}>
-                <div className={localClasses.flexOuterContainer}>
-                    <div className={localClasses.toolbarRow}>
+                <div className={classes.flexOuterContainer}>
+                    <div className={classes.toolbarRow}>
                         <Button
                             id="startAnimation"
                             style={{ color: appTheme.ForegroundColor }}
@@ -200,7 +200,7 @@ export default function RealtimeGhostedTraces() {
                         <span style={{ margin: 12 }}>FPS: {stats.fps.toFixed(0)}</span>
                     </div>
                     <SciChartReact
-                        className={localClasses.chartArea}
+                        className={classes.chartArea}
                         initChart={drawExample}
                         onInit={({ sciChartSurface, controls }: TResolvedReturnType<typeof drawExample>) => {
                             controlsRef.current = controls;

--- a/Examples/src/components/Examples/FeaturedApps/PerformanceDemos/RealtimePerformanceDemo/index.tsx
+++ b/Examples/src/components/Examples/FeaturedApps/PerformanceDemos/RealtimePerformanceDemo/index.tsx
@@ -35,13 +35,13 @@ export default function RealtimePerformanceDemo() {
 
     const [stats, setStats] = React.useState({ numberPoints: 0, fps: 0 });
 
-    const localClasses = useStyles();
+    const classes = useStyles();
 
     return (
         <React.Fragment>
             <div className={commonClasses.ChartWrapper}>
-                <div className={localClasses.flexOuterContainer}>
-                    <div className={localClasses.toolbarRow}>
+                <div className={classes.flexOuterContainer}>
+                    <div className={classes.toolbarRow}>
                         <Button
                             onClick={() => controlsRef.current.startDemo()}
                             style={{ color: appTheme.ForegroundColor }}
@@ -65,7 +65,7 @@ export default function RealtimePerformanceDemo() {
                         <span style={{ margin: 12 }}>FPS: {stats.fps.toFixed(0)}</span>
                     </div>
                     <SciChartReact
-                        className={localClasses.chartArea}
+                        className={classes.chartArea}
                         initChart={drawExample}
                         onInit={(initResult: TResolvedReturnType<typeof drawExample>) => {
                             controlsRef.current = initResult.controls;

--- a/Examples/src/components/Examples/FeaturedApps/PerformanceDemos/RealtimePerformanceDemo/index.tsx
+++ b/Examples/src/components/Examples/FeaturedApps/PerformanceDemos/RealtimePerformanceDemo/index.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { appTheme } from "../../../theme";
 import { SciChartReact, TResolvedReturnType } from "scichart-react";
-import classes from "../../../styles/Examples.module.scss";
+import commonClasses from "../../../styles/Examples.module.scss";
 import { drawExample } from "./drawExample";
 import Button from "@mui/material/Button";
 import { makeStyles } from "@mui/styles";
@@ -39,7 +39,7 @@ export default function RealtimePerformanceDemo() {
 
     return (
         <React.Fragment>
-            <div className={classes.ChartWrapper}>
+            <div className={commonClasses.ChartWrapper}>
                 <div className={localClasses.flexOuterContainer}>
                     <div className={localClasses.toolbarRow}>
                         <Button

--- a/Examples/src/components/Examples/FeaturedApps/PerformanceDemos/RealtimePerformanceDemo/index.tsx
+++ b/Examples/src/components/Examples/FeaturedApps/PerformanceDemos/RealtimePerformanceDemo/index.tsx
@@ -4,9 +4,9 @@ import { SciChartReact, TResolvedReturnType } from "scichart-react";
 import commonClasses from "../../../styles/Examples.module.scss";
 import { drawExample } from "./drawExample";
 import Button from "@mui/material/Button";
-import { makeStyles } from "@mui/styles";
+import { makeStyles } from "tss-react/mui";
 
-const useStyles = makeStyles((theme) => ({
+const useStyles = makeStyles()((theme) => ({
     flexOuterContainer: {
         width: "100%",
         height: "100%",
@@ -35,7 +35,7 @@ export default function RealtimePerformanceDemo() {
 
     const [stats, setStats] = React.useState({ numberPoints: 0, fps: 0 });
 
-    const classes = useStyles();
+    const { classes } = useStyles();
 
     return (
         <React.Fragment>

--- a/Examples/src/components/Examples/FeaturedApps/ScientificCharts/AudioAnalyzer/index.tsx
+++ b/Examples/src/components/Examples/FeaturedApps/ScientificCharts/AudioAnalyzer/index.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import classes from "../../../styles/Examples.module.scss";
+import commonClasses from "../../../styles/Examples.module.scss";
 import { SciChartGroup, SciChartReact } from "scichart-react";
 import { getChartsInitializationApi } from "./drawExample";
 import { appTheme } from "../../../theme";
@@ -9,7 +9,7 @@ export default function AudioAnalyzer() {
     const controlsRef = React.useRef<ReturnType<typeof chartsInitializationAPI.onAllChartsInit>>();
 
     return (
-        <div style={{ background: appTheme.Background }} className={classes.ChartWrapper}>
+        <div style={{ background: appTheme.Background }} className={commonClasses.ChartWrapper}>
             <div
                 style={{
                     width: "100%",

--- a/Examples/src/components/Examples/FeaturedApps/ScientificCharts/InteractiveWaterfallChart/index.tsx
+++ b/Examples/src/components/Examples/FeaturedApps/ScientificCharts/InteractiveWaterfallChart/index.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { appTheme } from "../../../theme";
 import { SciChartGroup, SciChartReact } from "scichart-react";
-import classes from "../../../styles/Examples.module.scss";
+import commonClasses from "../../../styles/Examples.module.scss";
 import { getChartsInitializationAPI } from "./drawExample";
 
 // React component needed as our examples app is react.
@@ -11,7 +11,7 @@ export default function InteractiveWaterfallChart() {
 
     return (
         <React.Fragment>
-            <div style={{ background: appTheme.Background }} className={classes.ChartWrapper}>
+            <div style={{ background: appTheme.Background }} className={commonClasses.ChartWrapper}>
                 <div
                     style={{
                         width: "100%",

--- a/Examples/src/components/Examples/FeaturedApps/ScientificCharts/LiDAR3DPointCloudDemo/index.tsx
+++ b/Examples/src/components/Examples/FeaturedApps/ScientificCharts/LiDAR3DPointCloudDemo/index.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import classes from "../../../styles/Examples.module.scss";
+import commonClasses from "../../../styles/Examples.module.scss";
 import { drawExample, drawHeatmapLegend } from "./drawExample";
 import { SciChartReact, TResolvedReturnType } from "scichart-react";
 
@@ -9,7 +9,7 @@ export default function LiDAR3DPointCloudDemo() {
     const sciChartSurfaceRef = React.useRef<SciChart3DSurface>();
 
     return (
-        <div className={classes.ChartWrapper}>
+        <div className={commonClasses.ChartWrapper}>
             <SciChartReact
                 initChart={drawExample}
                 style={{ height: "100%", width: "100%" }}

--- a/Examples/src/components/Examples/FeaturedApps/ScientificCharts/TenorCurves3D/index.tsx
+++ b/Examples/src/components/Examples/FeaturedApps/ScientificCharts/TenorCurves3D/index.tsx
@@ -1,12 +1,12 @@
 import * as React from "react";
-import classes from "../../../styles/Examples.module.scss";
+import commonClasses from "../../../styles/Examples.module.scss";
 import { draw3DChart, drawLineChart1, drawLineChart2, drawHeatmapLegend } from "./drawExaple";
 import { SciChartReact } from "scichart-react";
 
 export default function TenorCurves3DChart() {
     return (
         <React.Fragment>
-            <div className={classes.ChartWrapper} style={{ display: "flex" }}>
+            <div className={commonClasses.ChartWrapper} style={{ display: "flex" }}>
                 <div style={{ flex: "none", width: "50%", position: "relative" }}>
                     <SciChartReact initChart={draw3DChart} style={{ width: "100%", height: "100%" }} />
                     <SciChartReact

--- a/Examples/src/components/Examples/FeaturedApps/ShowCases/DynamicLayout/index.tsx
+++ b/Examples/src/components/Examples/FeaturedApps/ShowCases/DynamicLayout/index.tsx
@@ -18,7 +18,7 @@ import {
 } from "scichart";
 import { RandomWalkGenerator } from "../../../ExampleData/RandomWalkGenerator";
 import { appTheme } from "../../../theme";
-import classes from "../../../styles/Examples.module.scss";
+import commonClasses from "../../../styles/Examples.module.scss";
 import { GridLayoutModifier } from "./GridLayoutModifier";
 import { SciChartReact, SciChartSurfaceContext, TResolvedReturnType } from "scichart-react";
 import { useContext } from "react";
@@ -104,7 +104,7 @@ export default function DynamicLayout() {
 
     return (
         <React.Fragment>
-            <div className={classes.ChartWrapper}>
+            <div className={commonClasses.ChartWrapper}>
                 <SciChartReact
                     className={localClasses.flexOuterContainer}
                     innerContainerProps={{ className: localClasses.chartArea }}

--- a/Examples/src/components/Examples/FeaturedApps/ShowCases/DynamicLayout/index.tsx
+++ b/Examples/src/components/Examples/FeaturedApps/ShowCases/DynamicLayout/index.tsx
@@ -100,14 +100,14 @@ const useStyles = makeStyles((theme) => ({
 // React component needed as our examples app is react.
 // SciChart can be used in Angular, Vue, Blazor and vanilla JS! See our Github repo for more info
 export default function DynamicLayout() {
-    const localClasses = useStyles();
+    const classes = useStyles();
 
     return (
         <React.Fragment>
             <div className={commonClasses.ChartWrapper}>
                 <SciChartReact
-                    className={localClasses.flexOuterContainer}
-                    innerContainerProps={{ className: localClasses.chartArea }}
+                    className={classes.flexOuterContainer}
+                    innerContainerProps={{ className: classes.chartArea }}
                     initChart={drawExample}
                 >
                     <ChartToolbar />
@@ -118,7 +118,7 @@ export default function DynamicLayout() {
 }
 
 const ChartToolbar = () => {
-    const localClasses = useStyles();
+    const classes = useStyles();
     const initResult = useContext(SciChartSurfaceContext) as TResolvedReturnType<typeof drawExample>;
     const [isGrid, setIsGrid] = React.useState<boolean>(false);
 
@@ -127,7 +127,7 @@ const ChartToolbar = () => {
         setIsGrid(value);
     };
     return (
-        <div className={localClasses.toolbarRow}>
+        <div className={classes.toolbarRow}>
             <ToggleButtonGroup
                 exclusive
                 value={isGrid}

--- a/Examples/src/components/Examples/FeaturedApps/ShowCases/DynamicLayout/index.tsx
+++ b/Examples/src/components/Examples/FeaturedApps/ShowCases/DynamicLayout/index.tsx
@@ -1,4 +1,4 @@
-import { makeStyles } from "@mui/styles";
+import { makeStyles } from "tss-react/mui";
 import { ToggleButton, ToggleButtonGroup } from "@mui/material";
 import * as React from "react";
 import {
@@ -74,7 +74,7 @@ export const drawExample = async (rootElement: string | HTMLDivElement) => {
     return { wasmContext, sciChartSurface, setIsGridLayoutMode };
 };
 
-const useStyles = makeStyles((theme) => ({
+const useStyles = makeStyles()((theme) => ({
     flexOuterContainer: {
         width: "100%",
         height: "100%",
@@ -100,7 +100,7 @@ const useStyles = makeStyles((theme) => ({
 // React component needed as our examples app is react.
 // SciChart can be used in Angular, Vue, Blazor and vanilla JS! See our Github repo for more info
 export default function DynamicLayout() {
-    const classes = useStyles();
+    const { classes } = useStyles();
 
     return (
         <React.Fragment>
@@ -118,7 +118,7 @@ export default function DynamicLayout() {
 }
 
 const ChartToolbar = () => {
-    const classes = useStyles();
+    const { classes } = useStyles();
     const initResult = useContext(SciChartSurfaceContext) as TResolvedReturnType<typeof drawExample>;
     const [isGrid, setIsGrid] = React.useState<boolean>(false);
 

--- a/Examples/src/components/Examples/FeaturedApps/ShowCases/EventMarkers/index.tsx
+++ b/Examples/src/components/Examples/FeaturedApps/ShowCases/EventMarkers/index.tsx
@@ -1,11 +1,11 @@
 import * as React from "react";
 import { appTheme } from "../../../theme";
 import { SciChartReact } from "scichart-react";
-import classes from "../../../styles/Examples.module.scss";
+import commonClasses from "../../../styles/Examples.module.scss";
 import { drawExample } from "./drawExample";
 
 // React component needed as our examples app is react.
 // SciChart can be used in Angular, Vue, Blazor and vanilla JS! See our Github repo for more info
 export default function ChartComponent() {
-    return <SciChartReact initChart={drawExample} className={classes.ChartWrapper} />;
+    return <SciChartReact initChart={drawExample} className={commonClasses.ChartWrapper} />;
 }

--- a/Examples/src/components/Examples/FeaturedApps/ShowCases/HeatmapInteractions/index.tsx
+++ b/Examples/src/components/Examples/FeaturedApps/ShowCases/HeatmapInteractions/index.tsx
@@ -2,7 +2,7 @@ import Button from "@mui/material/Button";
 import { makeStyles } from "@mui/styles";
 import * as React from "react";
 import { appTheme } from "../../../theme";
-import classes from "../../../styles/Examples.module.scss";
+import commonClasses from "../../../styles/Examples.module.scss";
 import { getChartsInitializationApi, IChartControls } from "./drawExample";
 import { SciChartGroup, SciChartReact } from "scichart-react";
 
@@ -34,7 +34,7 @@ export default function HeatmapInteractions() {
 
     return (
         <React.Fragment>
-            <div className={classes.ChartWrapper}>
+            <div className={commonClasses.ChartWrapper}>
                 <div className={localClasses.flexOuterContainer}>
                     <div className={localClasses.toolbarRow}>
                         <Button

--- a/Examples/src/components/Examples/FeaturedApps/ShowCases/HeatmapInteractions/index.tsx
+++ b/Examples/src/components/Examples/FeaturedApps/ShowCases/HeatmapInteractions/index.tsx
@@ -28,15 +28,15 @@ const useStyles = makeStyles((theme) => ({
 }));
 
 export default function HeatmapInteractions() {
-    const localClasses = useStyles();
+    const classes = useStyles();
     const [chartsInitializationAPI] = React.useState(getChartsInitializationApi);
     const controlsRef = React.useRef<IChartControls>();
 
     return (
         <React.Fragment>
             <div className={commonClasses.ChartWrapper}>
-                <div className={localClasses.flexOuterContainer}>
-                    <div className={localClasses.toolbarRow}>
+                <div className={classes.flexOuterContainer}>
+                    <div className={classes.toolbarRow}>
                         <Button
                             disabled
                             id="startAnimation"

--- a/Examples/src/components/Examples/FeaturedApps/ShowCases/HeatmapInteractions/index.tsx
+++ b/Examples/src/components/Examples/FeaturedApps/ShowCases/HeatmapInteractions/index.tsx
@@ -1,12 +1,12 @@
 import Button from "@mui/material/Button";
-import { makeStyles } from "@mui/styles";
+import { makeStyles } from "tss-react/mui";
 import * as React from "react";
 import { appTheme } from "../../../theme";
 import commonClasses from "../../../styles/Examples.module.scss";
 import { getChartsInitializationApi, IChartControls } from "./drawExample";
 import { SciChartGroup, SciChartReact } from "scichart-react";
 
-const useStyles = makeStyles((theme) => ({
+const useStyles = makeStyles()((theme) => ({
     flexOuterContainer: {
         width: "100%",
         height: "100%",
@@ -28,7 +28,7 @@ const useStyles = makeStyles((theme) => ({
 }));
 
 export default function HeatmapInteractions() {
-    const classes = useStyles();
+    const { classes } = useStyles();
     const [chartsInitializationAPI] = React.useState(getChartsInitializationApi);
     const controlsRef = React.useRef<IChartControls>();
 

--- a/Examples/src/components/Examples/FeaturedApps/ShowCases/OilAndGasDashboard/index.tsx
+++ b/Examples/src/components/Examples/FeaturedApps/ShowCases/OilAndGasDashboard/index.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import classes from "../../../styles/Examples.module.scss";
+import commonClasses from "../../../styles/Examples.module.scss";
 import "./OIlGasStyles.css";
 
 import { SciChartVerticalGroup } from "scichart";
@@ -116,7 +116,7 @@ export default function OilAndGasDashboardShowcase() {
     }, []);
 
     return (
-        <div className={classes.ChartWrapper} style={{ display: "flex" }}>
+        <div className={commonClasses.ChartWrapper} style={{ display: "flex" }}>
             <div className="sidebar-charts">
                 <div id="sidebar-charts-2d" className="sidebar-charts-2d">
                     <div className="sidebar-charts-2d-title-container">

--- a/Examples/src/components/Examples/FeaturedApps/ShowCases/PopulationPyramid/index.tsx
+++ b/Examples/src/components/Examples/FeaturedApps/ShowCases/PopulationPyramid/index.tsx
@@ -1,11 +1,11 @@
 import * as React from "react";
 import { appTheme } from "../../../theme";
 import { SciChartReact } from "scichart-react";
-import classes from "../../../styles/Examples.module.scss";
+import commonClasses from "../../../styles/Examples.module.scss";
 import { drawExample } from "./drawExample";
 
 // React component needed as our examples app is react.
 // SciChart can be used in Angular, Vue, Blazor and vanilla JS! See our Github repo for more info
 export default function ChartComponent() {
-    return <SciChartReact initChart={drawExample} className={classes.ChartWrapper} />;
+    return <SciChartReact initChart={drawExample} className={commonClasses.ChartWrapper} />;
 }

--- a/Examples/src/components/Examples/FeaturedApps/ShowCases/ServerTrafficDashboard/index.tsx
+++ b/Examples/src/components/Examples/FeaturedApps/ShowCases/ServerTrafficDashboard/index.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import { CSSProperties, ChangeEventHandler, MouseEventHandler, useEffect, useRef, useState } from "react";
-import classes from "../../../styles/Examples.module.scss";
+import commonClasses from "../../../styles/Examples.module.scss";
 import { TChartConfigResult, synchronizeXVisibleRanges } from "./chart-configurations";
 import {
     ChartModifierBase2D,
@@ -188,7 +188,7 @@ function ServerTrafficDashboard() {
     };
 
     return (
-        <div className={classes.ChartWrapper} style={{ backgroundColor: "#242529" }}>
+        <div className={commonClasses.ChartWrapper} style={{ backgroundColor: "#242529" }}>
             {isDashboardInitialized ? null : <DashboardOverlay />}
             <div style={gridStyle}>
                 <SciChartGroup

--- a/Examples/src/components/Examples/FeaturedApps/ShowCases/WebsocketBigData/index.tsx
+++ b/Examples/src/components/Examples/FeaturedApps/ShowCases/WebsocketBigData/index.tsx
@@ -71,7 +71,7 @@ export default function RealtimeBigDataShowcase() {
         initialPoints: 6, // 1000000
     });
     const maxPoints = 10000000;
-    const localClasses = useStyles();
+    const classes = useStyles();
 
     const [results, setResults] = React.useState({
         dimensions: null,
@@ -176,10 +176,10 @@ export default function RealtimeBigDataShowcase() {
 
     return (
         <div className={commonClasses.ChartWrapper}>
-            <div className={localClasses.flexOuterContainer}>
+            <div className={classes.flexOuterContainer}>
                 <SciChartReact
                     key={seriesType}
-                    className={localClasses.chartArea}
+                    className={classes.chartArea}
                     style={{ flexBasis: 600, flexGrow: 1, flexShrink: 1 }}
                     initChart={chartInitFunction}
                     onInit={(initResult: TResolvedReturnType<typeof chartInitFunction>) => {

--- a/Examples/src/components/Examples/FeaturedApps/ShowCases/WebsocketBigData/index.tsx
+++ b/Examples/src/components/Examples/FeaturedApps/ShowCases/WebsocketBigData/index.tsx
@@ -9,7 +9,7 @@ import Slider from "@mui/material/Slider";
 import Button from "@mui/material/Button";
 import ButtonGroup from "@mui/material/ButtonGroup";
 import FormControl from "@mui/material/FormControl";
-import { makeStyles } from "@mui/styles";
+import { makeStyles } from "tss-react/mui";
 import Typography from "@mui/material/Typography";
 import Alert from "@mui/material/Alert";
 import AlertTitle from "@mui/material/AlertTitle";
@@ -26,7 +26,7 @@ import commonClasses from "../../../styles/Examples.module.scss";
 import { drawExample, ISettings, TMessage } from "./drawExample";
 import { SciChartReact, TResolvedReturnType } from "scichart-react";
 
-const useStyles = makeStyles((theme) => ({
+const useStyles = makeStyles()((theme) => ({
     flexOuterContainer: {
         width: "100%",
         height: "100%",
@@ -71,7 +71,7 @@ export default function RealtimeBigDataShowcase() {
         initialPoints: 6, // 1000000
     });
     const maxPoints = 10000000;
-    const classes = useStyles();
+    const { classes } = useStyles();
 
     const [results, setResults] = React.useState({
         dimensions: null,

--- a/Examples/src/components/Examples/FeaturedApps/ShowCases/WebsocketBigData/index.tsx
+++ b/Examples/src/components/Examples/FeaturedApps/ShowCases/WebsocketBigData/index.tsx
@@ -22,7 +22,7 @@ type Mark = typeof MuiSlider.prototype.defaultProps.marks;
 import * as React from "react";
 import { ESeriesType, SciChartSurface } from "scichart";
 import { appTheme } from "../../../theme";
-import classes from "../../../styles/Examples.module.scss";
+import commonClasses from "../../../styles/Examples.module.scss";
 import { drawExample, ISettings, TMessage } from "./drawExample";
 import { SciChartReact, TResolvedReturnType } from "scichart-react";
 
@@ -175,7 +175,7 @@ export default function RealtimeBigDataShowcase() {
     }, seriesType);
 
     return (
-        <div className={classes.ChartWrapper}>
+        <div className={commonClasses.ChartWrapper}>
             <div className={localClasses.flexOuterContainer}>
                 <SciChartReact
                     key={seriesType}
@@ -197,7 +197,7 @@ export default function RealtimeBigDataShowcase() {
                     }}
                 />
                 <div
-                    className={classes.notificationsBlock}
+                    className={commonClasses.notificationsBlock}
                     style={{
                         margin: "10 10 0 10",
                         color: appTheme.ForegroundColor,
@@ -207,7 +207,7 @@ export default function RealtimeBigDataShowcase() {
                     }}
                 >
                     <div>
-                        <FormControl className={classes.formControl}>
+                        <FormControl className={commonClasses.formControl}>
                             <ButtonGroup size="medium" color="primary" aria-label="small outlined button group">
                                 <Button id="startStreaming" onClick={handleStartStreaming}>
                                     {isDirty ? "ReStart" : "Start"}
@@ -218,7 +218,7 @@ export default function RealtimeBigDataShowcase() {
                             </ButtonGroup>
                         </FormControl>
                     </div>
-                    <FormControl className={classes.formControl}>
+                    <FormControl className={commonClasses.formControl}>
                         <RadioGroup id="chartType" value={seriesType} onChange={changeChart}>
                             <FormControlLabel value={ESeriesType.LineSeries} control={<Radio />} label="Line Chart" />
                             <FormControlLabel
@@ -301,7 +301,7 @@ export default function RealtimeBigDataShowcase() {
                         valueLabelDisplay="off"
                     />
                     {messages.length > 0 && (
-                        <Alert key="0" severity="info" className={classes.notification}>
+                        <Alert key="0" severity="info" className={commonClasses.notification}>
                             {messages.map((msg, index) => (
                                 <div key={index} style={{ paddingBottom: 10 }}>
                                     <AlertTitle style={{ lineHeight: 1 }}>{msg.title}</AlertTitle>

--- a/Examples/src/components/Examples/Toolbar.tsx
+++ b/Examples/src/components/Examples/Toolbar.tsx
@@ -85,7 +85,7 @@ export function InfoToolbar(props: { examplePage: TExamplePage }) {
         setIsOpen(false);
     };
 
-    const localClasses = useStyles({ isOpen });
+    const classes = useStyles({ isOpen });
 
     const { examplePage } = props;
     const documentationLinks = examplePage ? examplePage.documentationLinks : undefined;
@@ -110,8 +110,8 @@ export function InfoToolbar(props: { examplePage: TExamplePage }) {
 
     return (
         <SpeedDial
-            className={localClasses.speedDial}
-            classes={{ fab: localClasses.speedDialFab, root: localClasses.root }}
+            className={classes.speedDial}
+            classes={{ fab: classes.speedDialFab, root: classes.root }}
             open={isOpen}
             onClose={handleClose}
             onOpen={handleOpen}
@@ -126,9 +126,9 @@ export function InfoToolbar(props: { examplePage: TExamplePage }) {
             icon={
                 <SpeedDialIcon
                     classes={{
-                        root: localClasses.fabIcon,
-                        iconOpen: localClasses.iconOpen,
-                        icon: localClasses.icon,
+                        root: classes.fabIcon,
+                        iconOpen: classes.iconOpen,
+                        icon: classes.icon,
                     }}
                     icon={<InfoIcon fontSize="large" />}
                 />
@@ -138,11 +138,11 @@ export function InfoToolbar(props: { examplePage: TExamplePage }) {
             {actions.map((action) => (
                 <SpeedDialAction
                     classes={{
-                        fab: localClasses.actionButtonFab,
+                        fab: classes.actionButtonFab,
                     }}
                     key={action.name}
                     icon={
-                        <a className={localClasses.actionLink} href={action.href} target="_blank">
+                        <a className={classes.actionLink} href={action.href} target="_blank">
                             {action.icon}
                         </a>
                     }

--- a/Examples/src/components/Examples/Toolbar.tsx
+++ b/Examples/src/components/Examples/Toolbar.tsx
@@ -85,7 +85,7 @@ export function InfoToolbar(props: { examplePage: TExamplePage }) {
         setIsOpen(false);
     };
 
-    const classes = useStyles({ isOpen });
+    const localClasses = useStyles({ isOpen });
 
     const { examplePage } = props;
     const documentationLinks = examplePage ? examplePage.documentationLinks : undefined;
@@ -110,8 +110,8 @@ export function InfoToolbar(props: { examplePage: TExamplePage }) {
 
     return (
         <SpeedDial
-            className={classes.speedDial}
-            classes={{ fab: classes.speedDialFab, root: classes.root }}
+            className={localClasses.speedDial}
+            classes={{ fab: localClasses.speedDialFab, root: localClasses.root }}
             open={isOpen}
             onClose={handleClose}
             onOpen={handleOpen}
@@ -125,7 +125,11 @@ export function InfoToolbar(props: { examplePage: TExamplePage }) {
             }}
             icon={
                 <SpeedDialIcon
-                    classes={{ root: classes.fabIcon, iconOpen: classes.iconOpen, icon: classes.icon }}
+                    classes={{
+                        root: localClasses.fabIcon,
+                        iconOpen: localClasses.iconOpen,
+                        icon: localClasses.icon,
+                    }}
                     icon={<InfoIcon fontSize="large" />}
                 />
             }
@@ -134,11 +138,11 @@ export function InfoToolbar(props: { examplePage: TExamplePage }) {
             {actions.map((action) => (
                 <SpeedDialAction
                     classes={{
-                        fab: classes.actionButtonFab,
+                        fab: localClasses.actionButtonFab,
                     }}
                     key={action.name}
                     icon={
-                        <a className={classes.actionLink} href={action.href} target="_blank">
+                        <a className={localClasses.actionLink} href={action.href} target="_blank">
                             {action.icon}
                         </a>
                     }

--- a/Examples/src/components/Examples/Toolbar.tsx
+++ b/Examples/src/components/Examples/Toolbar.tsx
@@ -25,7 +25,6 @@ const CodeSandboxActionButton = () => <EditIcon></EditIcon>;
 
 const ShowSourceActionButton = () => <CodeIcon></CodeIcon>;
 
-// TODO jss-to-tss-react codemod: Unable to handle style definition reliably. ArrowFunctionExpression in CSS prop.
 const useStyles = makeStyles()((theme) => ({
     root: {},
     speedDial: {
@@ -37,13 +36,14 @@ const useStyles = makeStyles()((theme) => ({
         backgroundColor: appTheme.PaleBlue,
         border: "1px solid black",
         color: "white",
-        // opacity: (props: any) => (props.isOpen ? 1 : 0.5),
+        opacity: 0.5,
         "&:hover": {
             backgroundColor: appTheme.MutedBlue,
             opacity: 1,
         },
     },
     actionButtonFab: {
+        lineHeight: "1em",
         backgroundColor: appTheme.PaleBlue,
         border: "1px solid black",
         color: appTheme.ForegroundColor,
@@ -52,21 +52,23 @@ const useStyles = makeStyles()((theme) => ({
         },
     },
     fabIcon: {
+        lineHeight: "1em",
         height: "unset",
-        width: "unset",
+        // width: "unset",
     },
     iconOpen: {
-        transform: "unset",
-        opacity: 1,
+        // position: "relative",
+        // transform: "unset",
+        // opacity: 1,
     },
 
     icon: {
-        position: "absolute",
-        top: "50%",
-        transform: "translate(-50%, -50%)",
-        "&:hover": {
-            opacity: 1,
-        },
+        // position: "absolute",
+        // top: "50%",
+        // transform: "translate(-50%, -50%)",
+        // "&:hover": {
+        // opacity: 1,
+        // },
     },
 
     actionLink: {

--- a/Examples/src/components/Examples/Toolbar.tsx
+++ b/Examples/src/components/Examples/Toolbar.tsx
@@ -1,5 +1,5 @@
 import { useState, useContext } from "react";
-import { makeStyles, createStyles } from "@mui/styles";
+import { makeStyles } from "tss-react/mui";
 import { Theme } from "@mui/material/styles";
 import SpeedDialIcon from "@mui/material/SpeedDialIcon";
 import SpeedDialAction from "@mui/material/SpeedDialAction";
@@ -25,53 +25,54 @@ const CodeSandboxActionButton = () => <EditIcon></EditIcon>;
 
 const ShowSourceActionButton = () => <CodeIcon></CodeIcon>;
 
-const useStyles = makeStyles((theme: Theme) =>
-    createStyles({
-        root: {},
-        speedDial: {
-            position: "absolute",
-            top: 4,
-            right: 8,
-        },
-        speedDialFab: {
-            backgroundColor: appTheme.PaleBlue,
-            border: "1px solid black",
-            color: "white",
-            opacity: (props: any) => (props.isOpen ? 1 : 0.5),
-            "&:hover": {
-                backgroundColor: appTheme.MutedBlue,
-                opacity: 1,
-            },
-        },
-        actionButtonFab: {
-            backgroundColor: appTheme.PaleBlue,
-            border: "1px solid black",
-            color: appTheme.ForegroundColor,
-            "&:hover": {
-                backgroundColor: appTheme.MutedBlue,
-            },
-        },
-        fabIcon: {
-            height: "unset",
-            width: "unset",
-        },
-        iconOpen: {
-            transform: "unset",
+// TODO jss-to-tss-react codemod: Unable to handle style definition reliably. ArrowFunctionExpression in CSS prop.
+const useStyles = makeStyles()((theme) => ({
+    root: {},
+    speedDial: {
+        position: "absolute",
+        top: 4,
+        right: 8,
+    },
+    speedDialFab: {
+        backgroundColor: appTheme.PaleBlue,
+        border: "1px solid black",
+        color: "white",
+        // opacity: (props: any) => (props.isOpen ? 1 : 0.5),
+        "&:hover": {
+            backgroundColor: appTheme.MutedBlue,
             opacity: 1,
         },
-        icon: {
-            position: "absolute",
-            top: "50%",
-            transform: "translate(-50%, -50%)",
-            "&:hover": {
-                opacity: 1,
-            },
+    },
+    actionButtonFab: {
+        backgroundColor: appTheme.PaleBlue,
+        border: "1px solid black",
+        color: appTheme.ForegroundColor,
+        "&:hover": {
+            backgroundColor: appTheme.MutedBlue,
         },
-        actionLink: {
-            color: "inherit",
+    },
+    fabIcon: {
+        height: "unset",
+        width: "unset",
+    },
+    iconOpen: {
+        transform: "unset",
+        opacity: 1,
+    },
+
+    icon: {
+        position: "absolute",
+        top: "50%",
+        transform: "translate(-50%, -50%)",
+        "&:hover": {
+            opacity: 1,
         },
-    })
-);
+    },
+
+    actionLink: {
+        color: "inherit",
+    },
+}));
 
 export function InfoToolbar(props: { examplePage: TExamplePage }) {
     const framework = useContext(FrameworkContext);
@@ -85,7 +86,7 @@ export function InfoToolbar(props: { examplePage: TExamplePage }) {
         setIsOpen(false);
     };
 
-    const classes = useStyles({ isOpen });
+    const { classes } = useStyles();
 
     const { examplePage } = props;
     const documentationLinks = examplePage ? examplePage.documentationLinks : undefined;

--- a/Examples/src/components/Examples/styles/Examples.module.scss
+++ b/Examples/src/components/Examples/styles/Examples.module.scss
@@ -1,6 +1,6 @@
 @import "_base";
 .ExampleWrapperIFrame {
-    height: 100%;
+    height: 100vh;
     .ChartWrapper {
         width: 100%;
         height: 100%;
@@ -17,6 +17,7 @@
     overflow: hidden;
     position: relative;
     touch-action: none;
+    // this seems to be an optimal aspect ration to keep the whole chart in view
     aspect-ratio: 16 / 11;
     img {
         display: block;

--- a/Examples/src/components/Gallery/Gallery.tsx
+++ b/Examples/src/components/Gallery/Gallery.tsx
@@ -12,7 +12,8 @@ const Gallery: React.FC<TProps> = (props) => {
     const theme = useTheme();
 
     // Determine slider width based on screen size
-    const isXs = useMediaQuery(theme.breakpoints.down("sm")); // Mobile view
+    // TODO sm was changed by migration script.requires verification
+    const isXs = useMediaQuery(theme.breakpoints.down("md")); // Mobile view
     const isSm = useMediaQuery(theme.breakpoints.only("sm")); // Small view
     const slidersWidth = isXs ? 1 : isSm ? 3 : 5; // Default to 5 for larger screens
 

--- a/Examples/src/createEmotionCache.ts
+++ b/Examples/src/createEmotionCache.ts
@@ -1,0 +1,17 @@
+import createCache from "@emotion/cache";
+
+const isBrowser = typeof document !== "undefined";
+
+// On the client side, Create a meta tag at the top of the <head> and set it as insertionPoint.
+// This assures that Material UI styles are loaded first.
+// It allows developers to easily override Material UI styles with other styling solutions, like CSS modules.
+export default function createEmotionCache() {
+    let insertionPoint: HTMLElement | undefined;
+
+    if (isBrowser) {
+        const emotionInsertionPoint = document.querySelector('meta[name="emotion-insertion-point"]') as HTMLElement;
+        insertionPoint = emotionInsertionPoint ?? undefined;
+    }
+
+    return createCache({ key: "scichart-style", insertionPoint });
+}

--- a/Examples/src/index.tsx
+++ b/Examples/src/index.tsx
@@ -1,25 +1,23 @@
-import { useEffect } from "react";
 import { createRoot, hydrateRoot } from "react-dom/client";
 import { ThemeProvider } from "@mui/material/styles";
 import { BrowserRouter } from "react-router-dom";
 import App from "./components/App";
 import { customTheme } from "./theme";
 import "./components/index.scss";
+import { CacheProvider } from "@emotion/react";
+import createEmotionCache from "./createEmotionCache";
+
+const cache = createEmotionCache();
 
 function Main() {
-    useEffect(() => {
-        const jssStyles = document.querySelector("#jss-server-side");
-        if (jssStyles) {
-            jssStyles.parentElement.removeChild(jssStyles);
-        }
-    }, []);
-
     return (
-        <ThemeProvider theme={customTheme}>
-            <BrowserRouter>
-                <App />
-            </BrowserRouter>
-        </ThemeProvider>
+        <CacheProvider value={cache}>
+            <ThemeProvider theme={customTheme}>
+                <BrowserRouter>
+                    <App />
+                </BrowserRouter>
+            </ThemeProvider>
+        </CacheProvider>
     );
 }
 

--- a/Examples/src/server/renderCodeSandboxRedirect.ts
+++ b/Examples/src/server/renderCodeSandboxRedirect.ts
@@ -18,6 +18,7 @@ const renderCodeSandBoxRedirectPage = (config: SandboxConfig, framework: EPageFr
     const form = `<form name="codesandbox" id="codesandbox" action="https://codesandbox.io/api/v1/sandboxes/define" method="POST">
         <input type="hidden" name="parameters" value="${parameters}" />
         <input type="hidden" name="query" value="file=src/drawExample.ts" />
+        <input type="hidden" name="embed" value="1" />
         ${openInDevBox ? `<input type="hidden" name="environment" value="server" />` : ""}
     </form>`;
 

--- a/Examples/src/server/renderIndexHtml.ts
+++ b/Examples/src/server/renderIndexHtml.ts
@@ -29,10 +29,10 @@ export function renderIndexHtml(html: string, css: string, helmet: HelmetData) {
             <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.21.0/plugins/line-numbers/prism-line-numbers.min.css" />
             <link rel="stylesheet" href="style.css" />
 
-            <style id="jss-server-side">${css}</style>
+            <meta name="emotion-insertion-point" content="" />
+            ${css}
 
             <script async type="text/javascript" src="bundle.js"></script>
-
         </head>
         <body ${helmet.bodyAttributes.toString()} style="margin: 0;">
             <!-- Display a message if JS has been disabled on the browser. -->

--- a/Examples/src/server/server.tsx
+++ b/Examples/src/server/server.tsx
@@ -26,10 +26,7 @@ import { vanillaExamplesRouter } from "./vanillaDemo/vanillaExamplesRouter";
 import { EXAMPLES_PAGES } from "../components/AppRouter/examplePages";
 import { EPageFramework } from "../helpers/shared/Helpers/frameworkParametrization";
 import { getAvailableVariants } from "./variants";
-
-// Create an emotion cache for SSR
-const cache = createCache({ key: "css" });
-const { extractCriticalToChunks, constructStyleTagsFromChunks } = createEmotionServer(cache);
+import createEmotionCache from "../createEmotionCache";
 
 const port = parseInt(process.env.PORT || "3000", 10);
 const host = process.env.HOST || "localhost";
@@ -39,6 +36,10 @@ function handleRender(req: Request, res: Response) {
     if (req.query["codesandbox"]) {
         if (renderSandBoxRedirect(req, res, "codesandbox")) return;
     }
+
+    // Create an emotion cache for SSR
+    const cache = createEmotionCache();
+    const { extractCriticalToChunks, constructStyleTagsFromChunks } = createEmotionServer(cache);
 
     // Render the component to a string.
     const appHtml = ReactDOMServer.renderToString(

--- a/Examples/src/server/server.tsx
+++ b/Examples/src/server/server.tsx
@@ -106,15 +106,6 @@ app.get("/source/:example", (req: Request, res: Response) => {
     getSourceFiles(req, res);
 });
 
-app.get("/iframe/iframe/:example", (req: Request, res: Response) => {
-    const params = req.params;
-    if (getExamplePageKey(params.example)) {
-        return res.redirect(301, `../${params.example}`);
-    } else {
-        handleRender(req, res);
-    }
-});
-
 app.get("/iframe/codesandbox/:example", (req: Request, res: Response) => {
     handleRender(req, res);
 });

--- a/Examples/src/server/services/sandbox/reactConfig.ts
+++ b/Examples/src/server/services/sandbox/reactConfig.ts
@@ -40,10 +40,10 @@ export const getReactSandBoxConfig = async (
                 },
                 dependencies: {
                     "@emotion/react": "^11.13.3",
-                    "@emotion/styled": "^11.13.0",
+                    "@emotion/styled": "^11.13.0", // peer dependency of @mui/material
                     "@mui/material": "^5.15.20", // Change to MUI v5
                     "@mui/lab": "^5.0.0-alpha.170",
-                    "@mui/styles": "^5.15.21",
+                    "tss-react": "^4.9.13",
                     sass: "^1.49.9",
                     "loader-utils": "3.2.1",
                     react: "^18.3.1",

--- a/Examples/src/static/no_server.index.html
+++ b/Examples/src/static/no_server.index.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html lang="en-us">
     <head>
         <meta charset="utf-8" />
@@ -15,9 +16,12 @@
             href="https://fonts.googleapis.com/css2?family=Montserrat:ital,wght@0,100;0,400;0,600;0,700;1,100;1,400;1,600;1,700&display=swap"
             rel="stylesheet"
         />
+
+        <meta name="emotion-insertion-point" content="" />
+
         <script async type="text/javascript" src="bundle.js"></script>
     </head>
-    <body style="margin: 0;">
+    <body style="margin: 0">
         <div id="react-root"></div>
         <script>
             window.Prism = window.Prism || {};


### PR DESCRIPTION
Due to unfinished migradtion some issues appeared in rare cases, e.g. missing styles, broken layout, etc.  
Maybe this was not required, but seems it worked out just fine.  
The changes affected moslty only `Examples/src/components/Examples`.  
Used visual testing solution to verify the examples layout is correct.  

This PR follows the migaration guide https://mui.com/material-ui/migration/migration-v4/ to finilize the rendering setup and resolve occuring issues.

Main changes:
- updated SSR setup
- added `!DOCTYPE html`; resolved annoying rendring diffences between dev mode and prod mode 🥳 
- renamed styles varaible and import names to avoid conflicts during migration autofixes
- [migrated style system to `tss-react` ](https://mui.com/material-ui/migration/migrating-from-jss/#2-use-tss-react) 
  as this approach seems to introduce minimal diff compared to our previous approach
- fixed fullscreen layout issue
- fixed InfoToolbar layout

Misc:
- added class selector to the chart container to easily use it in VTs
- CodeSandbox export opens `embed` version instead of full env; 
  It seems to be a bit more lightweight, but that is ti be confirmed with some testing and feedback;
  couldn't find a way to do the same for Stackblitz
