### PR TITLE
Refactor BandSeries Example to use metadata and add subtitle component

### DIFF
--- a/Examples/src/components/AppDetailsRouters/AppDetailsRouter.tsx
+++ b/Examples/src/components/AppDetailsRouters/AppDetailsRouter.tsx
@@ -15,7 +15,7 @@ import { StackblitzEditor } from "../CodeSandbox/StackblitzEditor";
 import { SandboxPlatform } from "../CodeSandbox/SandboxPlatform";
 import { CodeActionButtons } from "./CodeActionButtons";
 import { CodePreview } from "../CodePreview/CodePreview";
-
+import { ExamplesSubtitle } from "./ExamplesSubtitle";
 import { SourceFilesContext } from "./SourceFilesLoading/SourceFilesContext";
 
 type TProps = {
@@ -221,7 +221,7 @@ const AppDetailsRouter: FC<TProps> = (props) => {
                             </h1>
 
                             {/* Github, stackblitz buttons visible on maxwidth layout */}
-                            {!(isMaxWidth) ? (
+                            {!isMaxWidth ? (
                                 <CodeActionButtons
                                     className={`${classes.tabbtnwrap} ${classes.hiddenSmall}`}
                                     {...{ currentExample, selectedFramework, selectedFile }}
@@ -232,35 +232,23 @@ const AppDetailsRouter: FC<TProps> = (props) => {
                         </div>
 
                         {/* Subtitle // this returns a <p> already */}
-                        <span
-                            style={
-                                isMaxWidth
-                                    ? {
-                                        width: "100%",
-                                        maxWidth: "min(100vh, 100vw)",
-                                        margin: "0 auto",
-                                        textAlign: "start",
-                                    }
-                                    : {}
-                            }
-                        >
-                            {currentExample.subtitle(selectedFramework)}
-                        </span>
+                        <ExamplesSubtitle
+                            content={currentExample.subtitle(selectedFramework)}
+                            isMaxWidth={isMaxWidth}
+                        />
 
                         {/* Main example section */}
                         {embedCode ? (
                             renderEditor()
                         ) : (
                             <div // Chart + Code section
-                                className={`${classes.dynamicFlexWrapper} ${isMaxWidth ? classes.maxWidth: ""}`}
-                            >   
+                                className={`${classes.dynamicFlexWrapper} ${isMaxWidth ? classes.maxWidth : ""}`}
+                            >
                                 <ExamplesRoot examplePage={currentExample} seeAlso={seeAlso} />
                                 <CodeActionButtons
                                     {...{ currentExample, selectedFramework, selectedFile }}
                                     onSandboxOpen={handleSandboxOpen}
-                                    className={`${classes.tabbtnwrap} ${
-                                        isMaxWidth ? "" : classes.hiddenLarge
-                                    }`}
+                                    className={`${classes.tabbtnwrap} ${isMaxWidth ? "" : classes.hiddenLarge}`}
                                     style={{ minHeight: 35, height: 35, padding: 0, width: "100%" }}
                                 />
                                 <CodePreview

--- a/Examples/src/components/AppDetailsRouters/ExamplesSubtitle.scss
+++ b/Examples/src/components/AppDetailsRouters/ExamplesSubtitle.scss
@@ -1,0 +1,10 @@
+.subtitle {
+    display: block;
+
+    &.maxWidth {
+        width: 100%;
+        max-width: min(100vh, 100vw);
+        margin: 0 auto;
+        text-align: start;
+    }
+}

--- a/Examples/src/components/AppDetailsRouters/ExamplesSubtitle.tsx
+++ b/Examples/src/components/AppDetailsRouters/ExamplesSubtitle.tsx
@@ -1,0 +1,22 @@
+import React, { FC, ReactElement } from "react";
+import ReactMarkdown from "react-markdown";
+import classes from "./ExamplesSubtitle.scss";
+
+type TSubtitleProps = {
+    content: ReactElement | string;
+    isMaxWidth?: boolean;
+};
+
+export const ExamplesSubtitle: FC<TSubtitleProps> = ({ content, isMaxWidth }) => {
+    const className = `${classes.subtitle} ${isMaxWidth ? classes.maxWidth : ""}`;
+
+    if (typeof content === "string") {
+        return (
+            <span className={className}>
+                <ReactMarkdown>{content}</ReactMarkdown>
+            </span>
+        );
+    }
+
+    return <span className={className}>{content}</span>;
+};

--- a/Examples/src/components/AppRouter/examplePages.ts
+++ b/Examples/src/components/AppRouter/examplePages.ts
@@ -1,3 +1,4 @@
+import React from "react";
 import { bandSeriesChartExampleInfo } from "../Examples/Charts2D/BasicChartTypes/BandSeriesChart/exampleInfo";
 import { splineBandSeriesChartExampleInfo } from "../Examples/Charts2D/BasicChartTypes/SplineBandSeriesChart/exampleInfo";
 import { digitalBandSeriesChartExampleInfo } from "../Examples/Charts2D/BasicChartTypes/DigitalBandSeriesChart/exampleInfo";
@@ -114,7 +115,6 @@ import { smoothStackedMountainChartExampleInfo } from "../Examples/Charts2D/Basi
 import { lineSplittingThresholdsExampleInfo } from "../Examples/Charts2D/StylingAndTheming/LineSplittingThresholds/exampleInfo";
 import { column3DChartExampleInfo } from "../Examples/Charts3D/Basic3DChartTypes/Column3DChart/exampleInfo";
 
-
 export type TExampleInfo = {
     /**
      * Example title
@@ -129,7 +129,7 @@ export type TExampleInfo = {
     /**
      * Content shown below title on example page
      */
-    subtitle: (frameworkName: string) => JSX.Element;
+    subtitle: (frameworkName: string) => React.ReactElement | string;
     /**
      * Page meta description
      */

--- a/Examples/src/components/Examples/Charts2D/BasicChartTypes/BandSeriesChart/BandSeriesChartMetadata.ts
+++ b/Examples/src/components/Examples/Charts2D/BasicChartTypes/BandSeriesChart/BandSeriesChartMetadata.ts
@@ -1,0 +1,53 @@
+export const metaData =
+    //// this file is generated, do not edit it!  JSON DATA >>>>>
+    {
+        exampleId: "bandChart",
+        imagePath: "javascript-band-chart.jpg",
+        title: "Band Chart",
+        description: "This chart type fills a polygon between two high and low lines...",
+        path: "band-chart",
+        metaKeywords: "band, chart, javascript, webgl, canvas",
+        onWebsite: true,
+        filepath: "Charts2D/BasicChartTypes/BandSeriesChart",
+        markdownContent: "",
+        tips: ["Great for rendering confidence intervals, error margins or Bollinger Bands!"],
+        frameworks: {
+            react: {
+                path: "Charts2D/BasicChartTypes/BandSeriesChart/react",
+                component: "BandChartComponent",
+                subtitle:
+                    "Demonstrates how to create a **React Band Chart** or High-Low Fill using SciChart.js, our High Performance [JavaScript Chart Framework](https://www.scichart.com/javascript-chart-features)",
+                title: "React Band Chart",
+                pageTitle: "React Band Chart | JavaScript Charts | View Examples",
+                metaDescription:
+                    "Easily create a React Band Chart or High-Low Fill with SciChart - high performance JavaScript Chart Library. Get your free trial now.",
+            },
+            angular: {
+                path: "Charts2D/BasicChartTypes/BandSeriesChart/angular",
+                component: "BandChartComponent",
+                subtitle:
+                    "Demonstrates how to create an **Angular Band Chart** or High-Low Fill using SciChart.js, our High Performance [JavaScript Chart Framework](https://www.scichart.com/javascript-chart-features)",
+                title: "Angular Band Chart",
+                pageTitle: "Angular Band Chart | JavaScript Charts | View Examples",
+                metaDescription:
+                    "Easily create an Angular Band Chart or High-Low Fill with SciChart - high performance JavaScript Chart Library. Get your free trial now.",
+            },
+            javascript: {
+                path: "Charts2D/BasicChartTypes/BandSeriesChart/vanilla",
+                component: "BandChartComponent",
+                subtitle:
+                    "Demonstrates how to create a **JavaScript Band Chart** or High-Low Fill using SciChart.js, our High Performance [JavaScript Chart Framework](https://www.scichart.com/javascript-chart-features)",
+                title: "JavaScript Band Chart",
+                pageTitle: "JavaScript Band Chart | JavaScript Charts | View Examples",
+                metaDescription:
+                    "Easily create a JavaScript Band Chart or High-Low Fill with SciChart - high performance JavaScript Chart Library. Get your free trial now.",
+            },
+        },
+        documentationLinks: [
+            {
+                href: "https://www.scichart.com/documentation/js/current/webframe.html#The%20Band%20Series%20type.html",
+                title: "The specific page for the JavaScript Digital Line Chart documentation will help you to get started",
+                linkTitle: "JavaScript Band Chart Documentation",
+            },
+        ],
+    };

--- a/Examples/src/components/Examples/Charts2D/BasicChartTypes/BandSeriesChart/BandSeriesChartMetadata.ts
+++ b/Examples/src/components/Examples/Charts2D/BasicChartTypes/BandSeriesChart/BandSeriesChartMetadata.ts
@@ -9,11 +9,9 @@ export const metaData =
         metaKeywords: "band, chart, javascript, webgl, canvas",
         onWebsite: true,
         filepath: "Charts2D/BasicChartTypes/BandSeriesChart",
-        markdownContent: "",
         tips: ["Great for rendering confidence intervals, error margins or Bollinger Bands!"],
         frameworks: {
             react: {
-                path: "Charts2D/BasicChartTypes/BandSeriesChart/react",
                 component: "BandChartComponent",
                 subtitle:
                     "Demonstrates how to create a **React Band Chart** or High-Low Fill using SciChart.js, our High Performance [JavaScript Chart Framework](https://www.scichart.com/javascript-chart-features)",
@@ -21,9 +19,9 @@ export const metaData =
                 pageTitle: "React Band Chart | JavaScript Charts | View Examples",
                 metaDescription:
                     "Easily create a React Band Chart or High-Low Fill with SciChart - high performance JavaScript Chart Library. Get your free trial now.",
+                markdownContent: "",
             },
             angular: {
-                path: "Charts2D/BasicChartTypes/BandSeriesChart/angular",
                 component: "BandChartComponent",
                 subtitle:
                     "Demonstrates how to create an **Angular Band Chart** or High-Low Fill using SciChart.js, our High Performance [JavaScript Chart Framework](https://www.scichart.com/javascript-chart-features)",
@@ -31,9 +29,9 @@ export const metaData =
                 pageTitle: "Angular Band Chart | JavaScript Charts | View Examples",
                 metaDescription:
                     "Easily create an Angular Band Chart or High-Low Fill with SciChart - high performance JavaScript Chart Library. Get your free trial now.",
+                markdownContent: "",
             },
             javascript: {
-                path: "Charts2D/BasicChartTypes/BandSeriesChart/vanilla",
                 component: "BandChartComponent",
                 subtitle:
                     "Demonstrates how to create a **JavaScript Band Chart** or High-Low Fill using SciChart.js, our High Performance [JavaScript Chart Framework](https://www.scichart.com/javascript-chart-features)",
@@ -41,6 +39,7 @@ export const metaData =
                 pageTitle: "JavaScript Band Chart | JavaScript Charts | View Examples",
                 metaDescription:
                     "Easily create a JavaScript Band Chart or High-Low Fill with SciChart - high performance JavaScript Chart Library. Get your free trial now.",
+                markdownContent: "",
             },
         },
         documentationLinks: [

--- a/Examples/src/components/Examples/Charts2D/BasicChartTypes/BandSeriesChart/exampleInfo.tsx
+++ b/Examples/src/components/Examples/Charts2D/BasicChartTypes/BandSeriesChart/exampleInfo.tsx
@@ -1,48 +1,30 @@
-import * as React from "react";
-import { TExampleInfo } from "../../../../AppRouter/examplePages";
-import { ExampleStrings } from "../../../ExampleStrings";
-import { TDocumentationLink } from "../../../../../helpers/types/ExampleDescriptionTypes";
-import exampleImage from "./javascript-band-chart.jpg";
-import { TFrameworkName } from "../../../../../helpers/shared/Helpers/frameworkParametrization";
+import { IExampleMetadata } from "../../../IExampleMetadata";
+import { metaData } from "./BandSeriesChartMetadata";
+import { createExampleInfo } from "../../../exampleInfoUtils";
 
-const previewDescription = `Band Charts fill a polygon between two high and low lines. The colour of the polygon changes depending on which line Y1 or Y2 is higher.`;
-const description = `This JavaScript chart type can be used to draw thresholds, a fill between two lines or areas of interest on a chart.`;
-const tips = [
-    `If you have data where Y1 is greater than Y2 always, you’ll get an envelope effect. Great for rendering
-    confidence intervals, error margins or Bollinger Bands!`,
-];
+// const previewDescription = `Band Charts fill a polygon between two high and low lines. The colour of the polygon changes depending on which line Y1 or Y2 is higher.`;
+// const description = `This JavaScript chart type can be used to draw thresholds, a fill between two lines or areas of interest on a chart.`;
+// const tips = [
+//     `If you have data where Y1 is greater than Y2 always, you'll get an envelope effect. Great for rendering
+//     confidence intervals, error margins or Bollinger Bands!`,
+// ];
 
-const documentationLinks: TDocumentationLink[] = [
-    {
-        href: ExampleStrings.urlBandChartDocumentation,
-        title: ExampleStrings.urlTitleDigitalLineChartDocumentation,
-        linkTitle: "JavaScript Band Chart Documentation",
-    },
-];
-
-const Subtitle = (frameworkName: string) => (
-    <>
-        Demonstrates how to create a <strong>{frameworkName} Band Chart</strong> or High-Low Fill using SciChart.js, our
-        High Performance{" "}
-        <a href={ExampleStrings.urlJavascriptChartFeatures} target="_blank" title="JavaScript Chart Framework">
-            JavaScript Chart Framework
-        </a>
-    </>
-);
-
-const markdownContent: string = undefined;
-
-export const bandSeriesChartExampleInfo: TExampleInfo = {
-    onWebsite: true,
-    title: ExampleStrings.titleBandChart,
-    pageTitle: ExampleStrings.pageTitleBandChart,
-    path: ExampleStrings.urlBandChart,
-    filepath: "Charts2D/BasicChartTypes/BandSeriesChart",
-    subtitle: Subtitle,
-    metaDescription: (frameworkName: TFrameworkName) =>
-        `Easily create a ${frameworkName} Band Chart or High-Low Fill with SciChart - high performance JavaScript Chart Library. Get your free trial now.`,
-    metaKeywords: "band, chart, javascript, webgl, canvas",
-    thumbnailImage: exampleImage,
-    markdownContent,
-    documentationLinks,
+// Original implementation commented out for reference
+/*
+export const bandSeriesChartExampleInfo = {
+    onWebsite: metaData.onWebsite,
+    title: (frameworkName: TFrameworkName) => metaData.frameworks[frameworkName.toLowerCase()].title,
+    pageTitle: (frameworkName: TFrameworkName) => metaData.frameworks[frameworkName.toLowerCase()].pageTitle,
+    path: metaData.path,
+    filepath: metaData.filepath,
+    subtitle: (frameworkName: string) => metaData.frameworks[frameworkName.toLowerCase()].subtitle,
+    metaDescription: (frameworkName: TFrameworkName) => metaData.frameworks[frameworkName.toLowerCase()].metaDescription,
+    metaKeywords: metaData.metaKeywords,
+    thumbnailImage: getExampleImage(metaData.imagePath),
+    markdownContent: metaData.markdownContent,
+    documentationLinks: metaData.documentationLinks
 };
+*/
+
+// New implementation using centralized utility
+export const bandSeriesChartExampleInfo = createExampleInfo(metaData as IExampleMetadata);

--- a/Examples/src/components/Examples/IExampleMetadata.ts
+++ b/Examples/src/components/Examples/IExampleMetadata.ts
@@ -1,0 +1,31 @@
+import { ExampleImagePath } from "./exampleImages";
+
+export interface IExampleMetadata {
+    exampleId: string; // Unique identifier for the example
+    imagePath: string; // Path to the example's thumbnail image
+    title: string; // Title of the example
+    description: string; // General description of the example
+    tips: string[]; // Array of tips related to the example
+    frameworks: Record<string, IFrameworkData>; // Framework-specific data keyed by framework name (e.g., "react", "angular", "javascript")
+    documentationLinks: IDocumentationLink[]; // Links to related documentation
+    path: string; // URL path for the example
+    metaKeywords: string; // Meta keywords for SEO
+    onWebsite: boolean; // Whether the example is shown on the website
+    filepath: string; // File path for the example
+    markdownContent: string | null; // Optional markdown content
+}
+
+export interface IDocumentationLink {
+    href: string; // URL for the documentation link
+    title: string; // Title of the documentation link
+    linkTitle: string; // Link title for the documentation link
+}
+
+export interface IFrameworkData {
+    path: string; // Path to the framework-specific implementation
+    component: string; // Name of the framework-specific component
+    subtitle: string; // Markdown formatted subtitle for the framework
+    title: string; // Framework-specific title
+    pageTitle: string; // Framework-specific page title
+    metaDescription: string; // Framework-specific meta description
+}

--- a/Examples/src/components/Examples/IExampleMetadata.ts
+++ b/Examples/src/components/Examples/IExampleMetadata.ts
@@ -12,7 +12,6 @@ export interface IExampleMetadata {
     metaKeywords: string; // Meta keywords for SEO
     onWebsite: boolean; // Whether the example is shown on the website
     filepath: string; // File path for the example
-    markdownContent: string | null; // Optional markdown content
 }
 
 export interface IDocumentationLink {
@@ -22,10 +21,10 @@ export interface IDocumentationLink {
 }
 
 export interface IFrameworkData {
-    path: string; // Path to the framework-specific implementation
     component: string; // Name of the framework-specific component
     subtitle: string; // Markdown formatted subtitle for the framework
     title: string; // Framework-specific title
     pageTitle: string; // Framework-specific page title
     metaDescription: string; // Framework-specific meta description
+    markdownContent: string | null; // Framework-specific markdown content
 }

--- a/Examples/src/components/Examples/exampleImages.ts
+++ b/Examples/src/components/Examples/exampleImages.ts
@@ -1,0 +1,34 @@
+import bandChartImage from "./Charts2D/BasicChartTypes/BandSeriesChart/javascript-band-chart.jpg";
+import bubbleChartImage from "./Charts2D/BasicChartTypes/BubbleChart/javascript-bubble-chart.jpg";
+import candlestickChartImage from "./Charts2D/BasicChartTypes/CandlestickChart/javascript-candlestick-chart.jpg";
+import columnChartImage from "./Charts2D/BasicChartTypes/ColumnChart/javascript-column-chart.jpg";
+import digitalBandChartImage from "./Charts2D/BasicChartTypes/DigitalBandSeriesChart/javascript-digital-band-chart.jpg";
+import lineChartImage from "./Charts2D/BasicChartTypes/LineChart/javascript-line-chart.jpg";
+
+export type ExampleImagePath =
+    | "javascript-band-chart.jpg"
+    | "javascript-bubble-chart.jpg"
+    | "javascript-candlestick-chart.jpg"
+    | "javascript-column-chart.jpg"
+    | "javascript-digital-band-chart.jpg"
+    | "javascript-line-chart.jpg";
+
+export const getExampleImage = (filename: string): string => {
+    switch (filename) {
+        case "javascript-band-chart.jpg":
+            return bandChartImage;
+        case "javascript-bubble-chart.jpg":
+            return bubbleChartImage;
+        case "javascript-candlestick-chart.jpg":
+            return candlestickChartImage;
+        case "javascript-column-chart.jpg":
+            return columnChartImage;
+        case "javascript-digital-band-chart.jpg":
+            return digitalBandChartImage;
+        case "javascript-line-chart.jpg":
+            return lineChartImage;
+        default:
+            console.warn(`Image not found: ${filename}`);
+            return "";
+    }
+};

--- a/Examples/src/components/Examples/exampleInfoUtils.ts
+++ b/Examples/src/components/Examples/exampleInfoUtils.ts
@@ -1,0 +1,19 @@
+import { TExampleInfo } from "../AppRouter/examplePages";
+import { TFrameworkName } from "../../helpers/shared/Helpers/frameworkParametrization";
+import { IExampleMetadata } from "./IExampleMetadata";
+import { getExampleImage } from "./exampleImages";
+
+export const createExampleInfo = (metadata: IExampleMetadata): TExampleInfo => ({
+    onWebsite: metadata.onWebsite,
+    title: (frameworkName: TFrameworkName) => metadata.frameworks[frameworkName.toLowerCase()].title,
+    pageTitle: (frameworkName: TFrameworkName) => metadata.frameworks[frameworkName.toLowerCase()].pageTitle,
+    path: metadata.path,
+    filepath: metadata.filepath,
+    subtitle: (frameworkName: string) => metadata.frameworks[frameworkName.toLowerCase()].subtitle,
+    metaDescription: (frameworkName: TFrameworkName) =>
+        metadata.frameworks[frameworkName.toLowerCase()].metaDescription,
+    metaKeywords: metadata.metaKeywords,
+    thumbnailImage: getExampleImage(metadata.imagePath),
+    markdownContent: metadata.markdownContent,
+    documentationLinks: metadata.documentationLinks,
+});

--- a/Examples/src/components/Examples/exampleInfoUtils.ts
+++ b/Examples/src/components/Examples/exampleInfoUtils.ts
@@ -14,6 +14,7 @@ export const createExampleInfo = (metadata: IExampleMetadata): TExampleInfo => (
         metadata.frameworks[frameworkName.toLowerCase()].metaDescription,
     metaKeywords: metadata.metaKeywords,
     thumbnailImage: getExampleImage(metadata.imagePath),
-    markdownContent: metadata.markdownContent,
+    markdownContent: (frameworkName: TFrameworkName) =>
+        metadata.frameworks[frameworkName.toLowerCase()].markdownContent,
     documentationLinks: metadata.documentationLinks,
 });


### PR DESCRIPTION
- Refactored BandSeries Example to get ExampleInfo from metadata
- Added subtitle component that can render React subcomponent or MD
- Centralized image handling
- This will serve as a template for all examples