### PR TITLE
feat(examples): serve webp versions of thumbnails as default while ke…

### DIFF
--- a/Examples/package.json
+++ b/Examples/package.json
@@ -94,6 +94,7 @@
     "file-loader": "^6.2.0",
     "husky": "^8.0.0",
     "ignore-loader": "^0.1.2",
+    "imagemin-webp-webpack-plugin": "^3.3.6",
     "mini-css-extract-plugin": "^2.7.2",
     "nodemon": "^2.0.20",
     "nodemon-webpack-plugin": "^4.8.1",

--- a/Examples/src/components/Gallery/GalleryCard.tsx
+++ b/Examples/src/components/Gallery/GalleryCard.tsx
@@ -3,6 +3,7 @@ import { useNavigate, Link } from "react-router";
 import classes from "./Gallery.module.scss";
 import { Tooltip } from "@mui/material";
 import { FrameworkContext } from "../../helpers/shared/Helpers/FrameworkContext";
+import { SciImage } from "../../helpers/shared/SciImage";
 
 type TProps = {
     imgPath: string;
@@ -20,8 +21,8 @@ const GalleryCard: FC<TProps> = (props) => {
     return (
         <div className={classes.GalleryItemCard}>
             <Link className={classes.GalleryItemCardImage} to={`/${framework}/${examplePath}`}>
-                <Tooltip title={<img src={imgPath} width={600} height={600} alt={seoTitle} />}>
-                    <img src={imgPath} data-title={seoTitle} alt={seoTitle} />
+                <Tooltip title={<SciImage src={imgPath} width={600} height={600} alt={seoTitle} />}>
+                    <SciImage src={imgPath} data-title={seoTitle} alt={seoTitle} />
                 </Tooltip>
                 <h5 className={classes.GalleryItemTitle}>{title}</h5>
             </Link>

--- a/Examples/src/components/GalleryItems/index.tsx
+++ b/Examples/src/components/GalleryItems/index.tsx
@@ -3,6 +3,7 @@ import classes from "./index.scss";
 import { Link, useNavigate } from "react-router";
 import { GalleryItem } from "../../helpers/types/types";
 import { FrameworkContext } from "../../helpers/shared/Helpers/FrameworkContext";
+import { SciImage } from "../../helpers/shared/SciImage";
 
 type TProps = {
     examples: GalleryItem[];
@@ -173,7 +174,7 @@ const Example: React.FC<{
                     {example.items.map((item, index) => (
                         <div key={index} className={classes.card} onClick={() => handleSubmenuClick(item.examplePath)}>
                             <div className={classes.imgWrapper}>
-                                <img src={item.imgPath} alt={item.seoTitle} title={item.title} />
+                                <SciImage src={item.imgPath} alt={item.seoTitle} title={item.title} />
                             </div>
                             <div className={classes.content}>
                                 <h3>{item.title}</h3>

--- a/Examples/src/helpers/shared/SciImage.tsx
+++ b/Examples/src/helpers/shared/SciImage.tsx
@@ -1,0 +1,16 @@
+import { DetailedHTMLProps, ImgHTMLAttributes } from "react";
+
+export function SciImage(
+    props: DetailedHTMLProps<ImgHTMLAttributes<HTMLImageElement>, HTMLImageElement> & { alt: string }
+) {
+    const originalPath = props.src;
+    const [basepath, ext] = originalPath.split(".");
+    const isReplaceable = ext === "png" || ext === "jpg" || ext === "jpeg";
+
+    return (
+        <picture>
+            {isReplaceable ? <source type="image/webp" srcSet={`${basepath}.webp`} /> : null}
+            <img {...props} />
+        </picture>
+    );
+}

--- a/Examples/webpack.client.config.js
+++ b/Examples/webpack.client.config.js
@@ -5,6 +5,7 @@ const config = require("./config/default");
 const autoprefixer = require("autoprefixer");
 const BundleAnalyzerPlugin = require("webpack-bundle-analyzer").BundleAnalyzerPlugin;
 const MiniCssExtractPlugin = require("mini-css-extract-plugin");
+const CssMinimizerPlugin = require("css-minimizer-webpack-plugin");
 
 const filename = (ext) => `[name].[hash].${ext}`;
 
@@ -59,6 +60,14 @@ module.exports = {
         filename: "bundle.js",
         path: path.resolve(__dirname, config.buildConfig.targetDir),
     },
+    // this is already done in the server build process, so probably there is no need doing it here
+    // optimization: {
+    //     minimizer: [
+    //         // For webpack@5 you can use the `...` syntax to extend existing minimizers (i.e. `terser-webpack-plugin`), uncomment the next line
+    //         `...`,
+    //         new CssMinimizerPlugin(),
+    //     ],
+    // },
     plugins: [
         new CopyPlugin({
             patterns: [

--- a/Examples/webpack.client.no_server.config.js
+++ b/Examples/webpack.client.no_server.config.js
@@ -2,6 +2,8 @@ const { merge } = require("webpack-merge");
 const webpackClientConfig = require("./webpack.client.config.js");
 const CopyPlugin = require("copy-webpack-plugin");
 const webpack = require("webpack");
+const ImageminWebpWebpackPlugin = require("imagemin-webp-webpack-plugin");
+
 const tq3080_DSM_2M = require("./src/server/Data/tq3080_DSM_2M");
 const { candlesADAUSDT } = require("./src/server/BinanceData/candlesADAUSDT");
 const { candlesBTCUSDT } = require("./src/server/BinanceData/candlesBTCUSDT");
@@ -65,6 +67,7 @@ module.exports = {
         ],
     },
     plugins: [
+        new ImageminWebpWebpackPlugin(),
         new CopyPlugin({
             patterns: [
                 { from: "src/static/no_server.index.html", to: "index.html" },

--- a/Examples/webpack.server.config.js
+++ b/Examples/webpack.server.config.js
@@ -4,6 +4,7 @@ const path = require("path");
 const config = require("./config/default");
 const nodeExternals = require("webpack-node-externals");
 const CssMinimizerPlugin = require("css-minimizer-webpack-plugin");
+const ImageminWebpWebpackPlugin = require("imagemin-webp-webpack-plugin");
 
 module.exports = {
     mode: "production",
@@ -73,6 +74,7 @@ module.exports = {
         ],
     },
     plugins: [
+        new ImageminWebpWebpackPlugin(),
         new CopyPlugin({
             patterns: [
                 {


### PR DESCRIPTION
Used [imagemin-webp-webpack-plugin[(https://www.npmjs.com/package/imagemin-webp-webpack-plugin) to generate **webp** thumbnail versions.
For now used the default options, but pottentially the settings could be tweaked.
![image](https://github.com/user-attachments/assets/7ec06dfa-8758-4dc8-af2d-3c115bce6968)
