### PR TITLE
make react component optional in examplemetadata

### DIFF
--- a/Examples/src/components/Examples/IExampleMetadata.ts
+++ b/Examples/src/components/Examples/IExampleMetadata.ts
@@ -15,7 +15,7 @@ export interface IExampleMetadata {
     extraDependencies?: Record<string, string>;
     sandboxConfig?: Record<string, any>;
     markdownContent?: string | null;
-    reactComponent: string | null;
+    reactComponent?: string | null;
 }
 
 export interface IDocumentationLink {


### PR DESCRIPTION
just made reactComponent property of example metadata optional so we can forget about it if we always have it as the default export.