### PR TITLE
fix(examples): Adding ts-ignore to AudioDataProvider classes to avoid…

### DIFF
--- a/Examples/src/components/Examples/FeaturedApps/ScientificCharts/AudioAnalyzer/AudioDataProvider.ts
+++ b/Examples/src/components/Examples/FeaturedApps/ScientificCharts/AudioAnalyzer/AudioDataProvider.ts
@@ -101,6 +101,8 @@ export class AudioDataProvider {
             throw new Error("Audio isn't initialized!");
         }
 
+        // needs to be cast `freqByteData as unknown as UInt8Array<ArrayBuffer>` or, ts-ignore
+        //@ts-ignore
         this.analyserNode.getByteTimeDomainData(this.freqByteData);
 
         for (let i = 0; i < this.bufferSizeProperty; i++) {

--- a/Examples/src/components/Examples/FeaturedApps/ScientificCharts/AudioAnalyzerBars/AudioDataProvider.ts
+++ b/Examples/src/components/Examples/FeaturedApps/ScientificCharts/AudioAnalyzerBars/AudioDataProvider.ts
@@ -100,7 +100,8 @@ export class AudioDataProvider {
         if (this.initialized === false) {
             throw new Error("Audio isn't initialized!");
         }
-
+        // needs to be cast `freqByteData as unknown as UInt8Array<ArrayBuffer>` or, ts-ignore
+        //@ts-ignore
         this.analyserNode.getByteTimeDomainData(this.freqByteData);
 
         for (let i = 0; i < this.bufferSizeProperty; i++) {


### PR DESCRIPTION
Fixes various errors 

```
C:\dev\SciChart.JS.Examples\Examples\src\components\Examples\FeaturedApps\ScientificCharts\AudioAnalyzerBars\AudioDataProvider.ts(104,49) 
TS2345: Argument of type 'Uint8Array<ArrayBufferLike>' is not assignable to parameter of type 'Uint8Array<ArrayBuffer>'.
  Type 'ArrayBufferLike' is not assignable to type 'ArrayBuffer'. 
  Type 'SharedArrayBuffer' is not assignable to type 'ArrayBuffer'. 
  Types of property '[Symbol.toStringTag]' are incompatible. 
  Type '"SharedArrayBuffer"' is not assignable to type '"ArrayBuffer"'.
```

This issue was caused by this line of code
`
this.analyserNode.getByteTimeDomainData(this.freqByteData);
`

`getByteTimeDomainData(array: Uint8Array<ArrayBuffer>): void;` is defined in lib.dom.d.ts `freqByteData` is type `Uint8Array`

One solution is to cast the `freqByteData` e.g. 

```
this.analyserNode.getByteTimeDomainData(this.freqByteData as unknown as Uint8Array<ArrayBuffer>);
```

however a ts-ignore works just as well